### PR TITLE
feat: Implement Feeless Operations for Gatekeeper and Miners in Task Management

### DIFF
--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -367,7 +367,7 @@ pub mod pallet {
 			Self::deposit_event(Event::MinerBanned { miner, reason });
 			Ok(().into())
 		}
-		
+
 		/// Update miner reputation (root only)
 		#[pallet::call_index(4)]
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::update_reputation())]
@@ -377,14 +377,14 @@ pub mod pallet {
 			reputation_change: i32,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			
+
 			let current = MinerReputation::<T>::get(&miner);
 			let new_reputation = if reputation_change < 0 {
 				current.saturating_sub(reputation_change.unsigned_abs())
 			} else {
 				current.saturating_add(reputation_change as u32)
 			};
-			
+
 			MinerReputation::<T>::insert(&miner, new_reputation);
 			Self::deposit_event(Event::MinerReputationUpdated {
 				miner,
@@ -421,17 +421,17 @@ pub mod pallet {
 		pub fn is_miner_banned(miner: &T::AccountId) -> bool {
 			BannedMiners::<T>::get(miner)
 		}
-		
+
 		pub fn miner_reputation(miner: &T::AccountId) -> u32 {
 			MinerReputation::<T>::get(miner)
 		}
-		
+
 		// Call this when a miner submits a bad task
 		pub fn penalize_miner(miner: &T::AccountId) {
 			let current = MinerReputation::<T>::get(miner);
 			let new_reputation = current.saturating_sub(1);
 			MinerReputation::<T>::insert(miner, new_reputation);
-			
+
 			// If reputation drops too low, auto-ban
 			if new_reputation < 5 {
 				BannedMiners::<T>::insert(miner, true);

--- a/pallets/edge-connect/src/tests.rs
+++ b/pallets/edge-connect/src/tests.rs
@@ -37,7 +37,7 @@ fn it_works_for_inserting_worker_into_correct_storage() {
 			api: api_info.clone(),
 			location: worker_location.clone(),
 			specs: worker_specs.clone(),
-			reputation: 0,
+			reputation: WorkerReputation::<BlockNumberFor<T>>::default(),
 			last_status_check: current_timestamp,
 		};
 
@@ -50,7 +50,7 @@ fn it_works_for_inserting_worker_into_correct_storage() {
 			api: api_info.clone(),
 			location: worker_location.clone(),
 			specs: worker_specs.clone(),
-			reputation: 0,
+			reputation: WorkerReputation::<BlockNumberFor<T>>::default(),
 			last_status_check: current_timestamp,
 		};
 
@@ -123,7 +123,7 @@ fn it_works_for_registering_domain() {
 			api: api_info.clone(),
 			location: worker_location.clone(),
 			specs: worker_specs.clone(),
-			reputation: 0,
+			reputation: WorkerReputation::<BlockNumberFor<T>>::default(),
 			last_status_check: current_timestamp,
 		};
 

--- a/pallets/edge-connect/src/tests.rs
+++ b/pallets/edge-connect/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{mock::*, Error, Event};
-use frame_system::pallet_prelude::BlockNumberFor;
 use frame_support::{assert_noop, assert_ok, sp_runtime::traits::ConstU32, BoundedVec};
+use frame_system::pallet_prelude::BlockNumberFor;
 
 use cyborg_primitives::worker::*;
 use sp_std::convert::TryFrom;

--- a/pallets/edge-connect/src/tests.rs
+++ b/pallets/edge-connect/src/tests.rs
@@ -1,4 +1,5 @@
 use crate::{mock::*, Error, Event};
+use frame_system::pallet_prelude::BlockNumberFor;
 use frame_support::{assert_noop, assert_ok, sp_runtime::traits::ConstU32, BoundedVec};
 
 use cyborg_primitives::worker::*;
@@ -37,7 +38,7 @@ fn it_works_for_inserting_worker_into_correct_storage() {
 			api: api_info.clone(),
 			location: worker_location.clone(),
 			specs: worker_specs.clone(),
-			reputation: WorkerReputation::<BlockNumberFor<T>>::default(),
+			reputation: WorkerReputation::<BlockNumberFor<Test>>::default(),
 			last_status_check: current_timestamp,
 		};
 
@@ -50,7 +51,7 @@ fn it_works_for_inserting_worker_into_correct_storage() {
 			api: api_info.clone(),
 			location: worker_location.clone(),
 			specs: worker_specs.clone(),
-			reputation: WorkerReputation::<BlockNumberFor<T>>::default(),
+			reputation: WorkerReputation::<BlockNumberFor<Test>>::default(),
 			last_status_check: current_timestamp,
 		};
 
@@ -123,7 +124,7 @@ fn it_works_for_registering_domain() {
 			api: api_info.clone(),
 			location: worker_location.clone(),
 			specs: worker_specs.clone(),
-			reputation: WorkerReputation::<BlockNumberFor<T>>::default(),
+			reputation: WorkerReputation::<BlockNumberFor<Test>>::default(),
 			last_status_check: current_timestamp,
 		};
 

--- a/pallets/edge-connect/src/weights.rs
+++ b/pallets/edge-connect/src/weights.rs
@@ -34,8 +34,7 @@ pub trait WeightInfo {
 	fn register_worker() -> Weight;
 	fn remove_worker() -> Weight;
     fn toggle_worker_visibility() -> Weight;
-	fn ban_miner() -> Weight;
-	fn update_reputation() -> Weight;
+	fn penalize_worker() -> Weight;
 }
 
 /// Weights for `pallet_edge_connect` using the Substrate node and recommended hardware.
@@ -77,28 +76,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 
-	/// Storage: `EdgeConnect::BannedMiners` (r:0 w:1)
-    /// Proof: `EdgeConnect::BannedMiners` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
-    fn ban_miner() -> Weight {
-        // Proof Size summary in bytes:
-        //  Measured:  `0`
-        //  Estimated: `0`
-        // Minimum execution time: 8_000_000 picoseconds.
-        Weight::from_parts(9_000_000, 0)
-            .saturating_add(T::DbWeight::get().writes(1_u64))
-    }
-
-    /// Storage: `EdgeConnect::MinerReputation` (r:1 w:1)
-    /// Proof: `EdgeConnect::MinerReputation` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
-    fn update_reputation() -> Weight {
-        // Proof Size summary in bytes:
-        //  Measured:  `76`
-        //  Estimated: `3514`
-        // Minimum execution time: 10_000_000 picoseconds.
-        Weight::from_parts(11_000_000, 3514)
-            .saturating_add(T::DbWeight::get().reads(1_u64))
-            .saturating_add(T::DbWeight::get().writes(1_u64))
-    }
+	fn penalize_worker() -> Weight {
+		Weight::from_parts(10_000_000, 3688)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 }
 
 // For backwards compatibility and tests.
@@ -138,23 +120,10 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+	fn penalize_worker() -> Weight {
+		Weight::from_parts(10_000_000, 3688)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
 
-	fn ban_miner() -> Weight {
-        // Proof Size summary in bytes:
-        //  Measured:  `0`
-        //  Estimated: `0`
-        // Minimum execution time: 8_000_000 picoseconds.
-        Weight::from_parts(9_000_000, 0)
-            .saturating_add(RocksDbWeight::get().writes(1_u64))
-    }
-
-    fn update_reputation() -> Weight {
-        // Proof Size summary in bytes:
-        //  Measured:  `76`
-        //  Estimated: `3514`
-        // Minimum execution time: 10_000_000 picoseconds.
-        Weight::from_parts(11_000_000, 3514)
-            .saturating_add(RocksDbWeight::get().reads(1_u64))
-            .saturating_add(RocksDbWeight::get().writes(1_u64))
-    }
 }

--- a/pallets/edge-connect/src/weights.rs
+++ b/pallets/edge-connect/src/weights.rs
@@ -34,6 +34,8 @@ pub trait WeightInfo {
 	fn register_worker() -> Weight;
 	fn remove_worker() -> Weight;
     fn toggle_worker_visibility() -> Weight;
+	fn ban_miner() -> Weight;
+	fn update_reputation() -> Weight;
 }
 
 /// Weights for `pallet_edge_connect` using the Substrate node and recommended hardware.
@@ -74,6 +76,29 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+
+	/// Storage: `EdgeConnect::BannedMiners` (r:0 w:1)
+    /// Proof: `EdgeConnect::BannedMiners` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
+    fn ban_miner() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `0`
+        //  Estimated: `0`
+        // Minimum execution time: 8_000_000 picoseconds.
+        Weight::from_parts(9_000_000, 0)
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
+
+    /// Storage: `EdgeConnect::MinerReputation` (r:1 w:1)
+    /// Proof: `EdgeConnect::MinerReputation` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
+    fn update_reputation() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `76`
+        //  Estimated: `3514`
+        // Minimum execution time: 10_000_000 picoseconds.
+        Weight::from_parts(11_000_000, 3514)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
 }
 
 // For backwards compatibility and tests.
@@ -113,4 +138,23 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+
+	fn ban_miner() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `0`
+        //  Estimated: `0`
+        // Minimum execution time: 8_000_000 picoseconds.
+        Weight::from_parts(9_000_000, 0)
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
+
+    fn update_reputation() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `76`
+        //  Estimated: `3514`
+        // Minimum execution time: 10_000_000 picoseconds.
+        Weight::from_parts(11_000_000, 3514)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
 }

--- a/pallets/payment/src/lib.rs
+++ b/pallets/payment/src/lib.rs
@@ -9,7 +9,6 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-use pallet_edge_connect::AccountWorkers;
 
 pub mod weights;
 use log::info;
@@ -192,7 +191,7 @@ pub mod pallet {
 		/// Admin sets a miner's reward rates for active and idle states.
 		/// In future we idle rates will be static , will be set through the runtime configuration
 		#[pallet::call_index(2)]
-		#[pallet::weight(10_000)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::set_reward_rates_for_miner())]
 		pub fn set_reward_rates_for_miner(
 			origin: OriginFor<T>,
 			miner: T::AccountId,
@@ -294,7 +293,7 @@ pub mod pallet {
 
 		/// Allows a new user to subscribe to compute by paying upfront.
 		#[pallet::call_index(6)]
-		#[pallet::weight(10_000)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::subscribe())]
 		pub fn subscribe(origin: OriginFor<T>, hours: u32) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			ensure!(
@@ -318,7 +317,7 @@ pub mod pallet {
 
 		/// Lets an existing user add more hours to their subscription.
 		#[pallet::call_index(7)]
-		#[pallet::weight(10_000)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::add_hours())]
 		pub fn add_hours(origin: OriginFor<T>, extra_hours: u32) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			ensure!(
@@ -344,7 +343,7 @@ pub mod pallet {
 
 		/// Admin sets the global subscription cost per compute hour.
 		#[pallet::call_index(8)]
-		#[pallet::weight(10_000)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::set_subscription_fee_per_hour())]
 		pub fn set_subscription_fee_per_hour(
 			origin: OriginFor<T>,
 			new_fee_per_hour: BalanceOf<T>,

--- a/pallets/payment/src/lib.rs
+++ b/pallets/payment/src/lib.rs
@@ -9,11 +9,10 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-
 pub mod weights;
+use cyborg_primitives::payment::RewardRates;
 use log::info;
 use sp_runtime::traits::CheckedAdd;
-use cyborg_primitives::payment::RewardRates;
 
 use sp_runtime::traits::Zero;
 pub use weights::*;
@@ -69,7 +68,6 @@ pub mod pallet {
 		// #[pallet::constant]
 		// type ConductorAccount: Get<Self::AccountId>;
 	}
-
 
 	/// Storage for global per-hour subscription fee.
 	#[pallet::storage]

--- a/pallets/payment/src/mock.rs
+++ b/pallets/payment/src/mock.rs
@@ -1,7 +1,6 @@
 pub use crate as pallet_payment;
 use frame_support::{derive_impl, parameter_types, weights::constants::RocksDbWeight};
 use frame_system::{mocking::MockBlock, GenesisConfig};
-use pallet_edge_connect::*;
 use pallet_sudo;
 use sp_runtime::{
 	traits::{ConstU32, ConstU64},

--- a/pallets/payment/src/tests.rs
+++ b/pallets/payment/src/tests.rs
@@ -2,7 +2,6 @@ use crate::mock::*;
 use crate::BalanceOf;
 use frame_support::traits::fungible::Mutate;
 use frame_support::{assert_noop, assert_ok};
-use pallet_edge_connect::*;
 
 // Test to ensure consuming zero hours fails
 #[test]

--- a/pallets/payment/src/weights.rs
+++ b/pallets/payment/src/weights.rs
@@ -37,6 +37,11 @@ pub trait WeightInfo {
 	fn purchase_compute_hours() -> Weight;
 	fn consume_compute_hours() -> Weight;
 
+	fn set_reward_rates_for_miner() -> Weight;
+    fn subscribe() -> Weight;
+    fn add_hours() -> Weight;
+    fn set_subscription_fee_per_hour() -> Weight;
+
 	// New extrinsics
 	fn record_usage() -> Weight;
 	fn reward_miner() -> Weight;
@@ -108,6 +113,28 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(16_000_000_000, 0)
 			.saturating_add(T::DbWeight::get().reads_writes(10, 10)) // adjust based on loop size
 	}
+
+	fn set_reward_rates_for_miner() -> Weight {
+        Weight::from_parts(3_000_000_000, 0)
+            .saturating_add(T::DbWeight::get().writes(2_u64))
+    }
+
+    fn subscribe() -> Weight {
+        Weight::from_parts(5_000_000_000, 0)
+            .saturating_add(T::DbWeight::get().reads(3_u64))
+            .saturating_add(T::DbWeight::get().writes(2_u64))
+    }
+
+    fn add_hours() -> Weight {
+        Weight::from_parts(4_000_000_000, 0)
+            .saturating_add(T::DbWeight::get().reads(3_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
+
+    fn set_subscription_fee_per_hour() -> Weight {
+        Weight::from_parts(2_000_000_000, 0)
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
 	
 	
 
@@ -177,5 +204,27 @@ impl WeightInfo for () {
 		Weight::from_parts(16_000_000_000, 0)
 			.saturating_add(RocksDbWeight::get().reads_writes(10, 10))
 	}
+
+	fn set_reward_rates_for_miner() -> Weight {
+        Weight::from_parts(3_000_000_000, 0)
+            .saturating_add(RocksDbWeight::get().writes(2_u64))
+    }
+
+    fn subscribe() -> Weight {
+        Weight::from_parts(5_000_000_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(3_u64))
+            .saturating_add(RocksDbWeight::get().writes(2_u64))
+    }
+
+    fn add_hours() -> Weight {
+        Weight::from_parts(4_000_000_000, 0)
+            .saturating_add(RocksDbWeight::get().reads(3_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
+
+    fn set_subscription_fee_per_hour() -> Weight {
+        Weight::from_parts(2_000_000_000, 0)
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
 	
 }

--- a/pallets/status-aggregator/src/tests.rs
+++ b/pallets/status-aggregator/src/tests.rs
@@ -5,19 +5,14 @@ use crate::{
 	WorkerStatusEntriesPerPeriod,
 };
 
-use frame_support::{
-	assert_noop, assert_ok, pallet_prelude::ConstU32, sp_runtime::RuntimeDebug,
-	testing_prelude::bounded_vec, traits::OnFinalize, BoundedVec,
-};
+use frame_support::{assert_ok, pallet_prelude::ConstU32, traits::OnFinalize, BoundedVec};
 use frame_system::pallet_prelude::BlockNumberFor;
-use orml_oracle;
-use orml_traits::{CombineData, OnNewData};
+use orml_traits::OnNewData;
 
 use cyborg_primitives::{
-	oracle::{OracleWorkerFormat, ProcessStatus, TimestampedValue},
+	oracle::{OracleWorkerFormat, ProcessStatus},
 	worker::*,
 };
-use std::error::Error;
 
 #[test]
 fn prevents_nonexistent_worker_storage() {

--- a/pallets/task-management/src/lib.rs
+++ b/pallets/task-management/src/lib.rs
@@ -15,21 +15,18 @@ pub mod weights;
 pub use weights::*;
 
 use frame_support::{pallet_prelude::ConstU32, BoundedVec};
-use scale_info::prelude::vec::Vec;
-use sp_core::hash::H256;
 
 pub use cyborg_primitives::task::*;
-use cyborg_primitives::worker::{WorkerId, WorkerStatusType};
+use cyborg_primitives::worker::WorkerId;
+
 
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
 	use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
 	use frame_system::pallet_prelude::{OriginFor, *};
-	use pallet_edge_connect::{AccountWorkers, ExecutableWorkers, WorkerClusters};
-	use pallet_payment::ComputeHours;
-
-
+	use pallet_edge_connect::AccountWorkers;
+	use frame_support::dispatch::PostDispatchInfo;
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]
@@ -69,19 +66,19 @@ pub mod pallet {
 	pub type Tasks<T: Config> =
 		StorageMap<_, Identity, TaskId, TaskInfo<T::AccountId, BlockNumberFor<T>>, OptionQuery>;
 
+	#[pallet::storage]
+	pub type GatekeeperAccount<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
+
 	/// Storage for compute aggregation information (start and end block).
-    #[pallet::storage]
-    #[pallet::getter(fn compute_aggregations)]
-    pub type ComputeAggregations<T: Config> = StorageMap<
-        _, 
-        Blake2_128Concat, 
-        TaskId, 
-        (BlockNumberFor<T>, Option<BlockNumberFor<T>>), 
-        OptionQuery
-    >;
-
-
-	
+	#[pallet::storage]
+	#[pallet::getter(fn compute_aggregations)]
+	pub type ComputeAggregations<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		TaskId,
+		(BlockNumberFor<T>, Option<BlockNumberFor<T>>),
+		OptionQuery,
+	>;
 
 	/// Pallets use events to inform users when important changes are made.
 	/// <https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html#event-and-error>
@@ -91,30 +88,21 @@ pub mod pallet {
 		/// A new task has been scheduled and assigned to a worker.
 		TaskScheduled {
 			assigned_worker: (T::AccountId, WorkerId),
-			task_kind: TaskKind, 
+			task_kind: TaskKind,
 			task_owner: T::AccountId,
 			task_id: TaskId,
 			task: BoundedVec<u8, ConstU32<500>>,
 			zk_files_cid: Option<BoundedVec<u8, ConstU32<500>>>,
 		},
-	
+
 		/// A worker confirmed reception of task data and started execution.
-		TaskReceptionConfirmed {
-			task_id: TaskId,
-			who: T::AccountId,
-		},
-		
-	
-	
+		TaskReceptionConfirmed { task_id: TaskId, who: T::AccountId },
+
 		/// Controller/admin requested to stop a running task.
-		TaskStopRequested {
-			task_id: TaskId,
-		},
-	
+		TaskStopRequested { task_id: TaskId },
+
 		/// Miner confirmed that they have vacated/reset after stopping.
-		MinerVacated {
-			task_id: TaskId,
-		},
+		MinerVacated { task_id: TaskId },
 	}
 
 	/// Errors inform users that something went wrong.
@@ -127,20 +115,19 @@ pub mod pallet {
 		TaskNotFound,
 		// Scheduling errors
 		RequireComputeHoursDeposit, // A compute hour deposit is required to schedule or proceed with the task.
-		ZkFilesMissing,			// The user submitted a ZK task, but has not provided the required files for proof generation
-		NoWorkersAvailable,  // No workers are available for the task.
-	
+		ZkFilesMissing, // The user submitted a ZK task, but has not provided the required files for proof generation
+		NoWorkersAvailable, // No workers are available for the task.
+
 		// General task errors
-		UnassignedTaskId, // The provided task ID does not exist.
-		InvalidTaskOwner, // The caller is not the task owner.
-		TaskVerificationNotFound, 	// The task verification process cannot be found.
+		UnassignedTaskId,         // The provided task ID does not exist.
+		InvalidTaskOwner,         // The caller is not the task owner.
+		TaskVerificationNotFound, // The task verification process cannot be found.
 
 		// Status transition errors
 		RequireAssignedTask, // A task must be assigned before it can proceed to the next step.
 
 		// Verification-specific errors
 		RequireAssignedVerifier, // A verifier must be assigned to the task.
-		
 	}
 
 	#[pallet::call]
@@ -157,39 +144,44 @@ pub mod pallet {
 			worker_owner: T::AccountId,
 			worker_id: WorkerId,
 			compute_hours_deposit: Option<u32>,
-		) -> DispatchResult {
+		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin.clone())?;
-		
+
+			let pays_fee = if who == GatekeeperAccount::<T>::get().expect("Invalid Gatekeper") {
+				Pays::No
+			} else {
+				Pays::Yes
+			};
+
 			// Validate deposit
 			let deposit = compute_hours_deposit.ok_or(Error::<T>::RequireComputeHoursDeposit)?;
 			ensure!(deposit > 0, Error::<T>::RequireComputeHoursDeposit);
-		
+
 			// Check task_type and task_kind compatibility
 			match task_kind {
 				TaskKind::NeuroZK => {
 					// For NeuroZK, zk_files_cid must be present
 					ensure!(zk_files_cid.is_some(), Error::<T>::ZkFilesMissing);
-			
-				},
+				}
 				TaskKind::OpenInference => {
 					// zk_files_cid should not be present for normal inference
 					ensure!(zk_files_cid.is_none(), Error::<T>::UnexpectedZkFiles);
-				},
+				}
 			}
-		
+
 			// Ensure there's at least one worker registered
 			let existing_workers = AccountWorkers::<T>::iter().next().is_some();
 			ensure!(existing_workers, Error::<T>::NoWorkersAvailable);
-		
+
 			// Consume compute hours from payment pallet
 			pallet_payment::Pallet::<T>::consume_compute_hours(origin.clone(), deposit)?;
-		
+
 			// Generate task ID
 			let task_id = NextTaskId::<T>::get();
 			NextTaskId::<T>::put(task_id.wrapping_add(1));
-		
+
 			let selected_worker = (worker_owner, worker_id);
-		
+
 			let task_info = TaskInfo::<T::AccountId, BlockNumberFor<T>> {
 				task_owner: who.clone(),
 				create_block: <frame_system::Pallet<T>>::block_number(),
@@ -203,22 +195,25 @@ pub mod pallet {
 				consume_compute_hours: None,
 				task_status: TaskStatusType::Assigned,
 			};
-		
+
 			TaskAllocations::<T>::insert(task_id, selected_worker.clone());
 			TaskOwners::<T>::insert(task_id, who.clone());
 			Tasks::<T>::insert(task_id, task_info);
 			TaskStatus::<T>::insert(task_id, TaskStatusType::Assigned);
-		
+
 			Self::deposit_event(Event::TaskScheduled {
 				assigned_worker: selected_worker,
-				task_kind, 
+				task_kind,
 				task_owner: who,
 				task_id,
 				task: task_data,
 				zk_files_cid,
 			});
-		
-			Ok(())
+
+			Ok(PostDispatchInfo {
+				actual_weight: None,
+				pays_fee,
+			})
 		}
 
 		/// Miner confirms that it has gathered the data and is starting task execution.
@@ -226,106 +221,117 @@ pub mod pallet {
 		/// Allowed only if task is still `Assigned`.
 		/// Changes task state to `Running` and starts aggregation of resource usage.
 		#[pallet::call_index(1)]
-		#[pallet::weight(10_000)]
-		pub fn confirm_task_reception(
-			origin: OriginFor<T>,
-			task_id: TaskId,
-		) -> DispatchResult {
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::confirm_task_reception())]
+		pub fn confirm_task_reception(origin: OriginFor<T>, task_id: TaskId) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-		
+
 			// Load task
 			let mut task_info = Tasks::<T>::get(task_id).ok_or(Error::<T>::UnassignedTaskId)?;
-		
+
 			// Check that caller is the assigned worker
-			let assigned_worker = TaskAllocations::<T>::get(task_id).ok_or(Error::<T>::UnassignedTaskId)?;
+			let assigned_worker =
+				TaskAllocations::<T>::get(task_id).ok_or(Error::<T>::UnassignedTaskId)?;
 			ensure!(assigned_worker.0 == who, Error::<T>::InvalidTaskOwner);
-		
+
 			// Task must currently be `Assigned`
 			ensure!(
 				task_info.task_status == TaskStatusType::Assigned,
 				Error::<T>::RequireAssignedTask
 			);
-		
+
 			// Transition task to `Running`
 			task_info.task_status = TaskStatusType::Running;
-			TaskStatus::<T>::insert(task_id,TaskStatusType::Running);
+			TaskStatus::<T>::insert(task_id, TaskStatusType::Running);
 
-		
 			// Store back the updated task info
 			Tasks::<T>::insert(task_id, task_info);
-		
+
 			// Start compute aggregation: record starting block
 			ComputeAggregations::<T>::insert(
 				task_id,
-				(<frame_system::Pallet<T>>::block_number(), None::<BlockNumberFor<T>>),
+				(
+					<frame_system::Pallet<T>>::block_number(),
+					None::<BlockNumberFor<T>>,
+				),
 			);
-		
+
 			// Emit event (you can define a new event like TaskReceptionConfirmed if needed)
-			Self::deposit_event(Event::TaskReceptionConfirmed {
-				task_id,
-				who,
-			});
-		
+			Self::deposit_event(Event::TaskReceptionConfirmed { task_id, who });
+
 			Ok(())
 		}
 
-		// 
+		//
 		/// signals the miner to exit task execution and reset itself
 		/// Admin will make status to stopped
 		/// RUnning -> Stopped
 		#[pallet::call_index(5)]
-		#[pallet::weight(10_000)]
-		pub fn stop_task_and_vacate_miner(origin: OriginFor<T>,task_id: TaskId,)->DispatchResult{
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::stop_task_and_vacate_miner())]
+		pub fn stop_task_and_vacate_miner(origin: OriginFor<T>, task_id: TaskId) -> DispatchResult {
 			ensure_signed(origin)?; // anyone controlling can request stop
 
-            let mut task = Tasks::<T>::get(task_id).ok_or(Error::<T>::TaskNotFound)?;
+			let mut task = Tasks::<T>::get(task_id).ok_or(Error::<T>::TaskNotFound)?;
 
-            // Ensure task is running.
-            ensure!(task.task_status == TaskStatusType::Running, Error::<T>::InvalidTaskState);
+			// Ensure task is running.
+			ensure!(
+				task.task_status == TaskStatusType::Running,
+				Error::<T>::InvalidTaskState
+			);
 
-            // Change task state to Stopped.
-            task.task_status = TaskStatusType::Stopped;
-            Tasks::<T>::insert(task_id, task);
+			// Change task state to Stopped.
+			task.task_status = TaskStatusType::Stopped;
+			Tasks::<T>::insert(task_id, task);
 
-            // Mark end of compute aggregation.
-            ComputeAggregations::<T>::mutate(task_id, |record| {
-                if let Some((start, _)) = record {
-                    *record = Some((*start, Some(<frame_system::Pallet<T>>::block_number())));
-                }
-            });
+			// Mark end of compute aggregation.
+			ComputeAggregations::<T>::mutate(task_id, |record| {
+				if let Some((start, _)) = record {
+					*record = Some((*start, Some(<frame_system::Pallet<T>>::block_number())));
+				}
+			});
 
-            // Emit event.
-            Self::deposit_event(Event::TaskStopRequested { task_id });
+			// Emit event.
+			Self::deposit_event(Event::TaskStopRequested { task_id });
 
-            Ok(())
-			
+			Ok(())
 		}
-		
+
 		/// miner confirms that it has reset itself
-		/// Stopped to vacated 
+		/// Stopped to vacated
 		#[pallet::call_index(6)]
-		#[pallet::weight(10_000)]
-		pub fn confirm_miner_vacation(origin:OriginFor<T>,task_id:TaskId)->DispatchResult{
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::confirm_miner_vacation())]
+		pub fn confirm_miner_vacation(origin: OriginFor<T>, task_id: TaskId) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
-            let mut task = Tasks::<T>::get(task_id).ok_or(Error::<T>::TaskNotFound)?;
+			let mut task = Tasks::<T>::get(task_id).ok_or(Error::<T>::TaskNotFound)?;
 
-            // Ensure task owner is confirming.
-            ensure!(task.task_owner == who, Error::<T>::NotTaskOwner);
+			// Ensure task owner is confirming.
+			ensure!(task.task_owner == who, Error::<T>::NotTaskOwner);
 
-            // Ensure task is stopped.
-            ensure!(task.task_status == TaskStatusType::Stopped, Error::<T>::InvalidTaskState);
+			// Ensure task is stopped.
+			ensure!(
+				task.task_status == TaskStatusType::Stopped,
+				Error::<T>::InvalidTaskState
+			);
 
-            // Move to Vacated state.
-            task.task_status = TaskStatusType::Vacated;
-            Tasks::<T>::insert(task_id, task);
+			// Move to Vacated state.
+			task.task_status = TaskStatusType::Vacated;
+			Tasks::<T>::insert(task_id, task);
 
-            // Emit event.
-            Self::deposit_event(Event::MinerVacated { task_id });
+			// Emit event.
+			Self::deposit_event(Event::MinerVacated { task_id });
 
-            Ok(())
+			Ok(())
 		}
 
-	
+		#[pallet::call_index(4)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::set_gatekeeper())]
+		pub fn set_gatekeeper(
+			origin: OriginFor<T>,
+			new_gatekeeper: T::AccountId,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+			GatekeeperAccount::<T>::put(new_gatekeeper);
+			Ok(().into())
+		}
 	}
 }

--- a/pallets/task-management/src/lib.rs
+++ b/pallets/task-management/src/lib.rs
@@ -19,14 +19,13 @@ use frame_support::{pallet_prelude::ConstU32, BoundedVec};
 pub use cyborg_primitives::task::*;
 use cyborg_primitives::worker::WorkerId;
 
-
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
+	use frame_support::dispatch::PostDispatchInfo;
 	use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
 	use frame_system::pallet_prelude::{OriginFor, *};
 	use pallet_edge_connect::AccountWorkers;
-	use frame_support::dispatch::PostDispatchInfo;
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]
@@ -147,8 +146,12 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin.clone())?;
 
-			let pays_fee = if who == GatekeeperAccount::<T>::get().expect("Invalid Gatekeper") {
-				Pays::No
+			let pays_fee = if let Some(gatekeeper) = GatekeeperAccount::<T>::get() {
+				if who == gatekeeper {
+					Pays::No
+				} else {
+					Pays::Yes
+				}
 			} else {
 				Pays::Yes
 			};

--- a/pallets/task-management/src/tests.rs
+++ b/pallets/task-management/src/tests.rs
@@ -27,7 +27,7 @@ fn register_worker(
 }
 
 fn setup_gatekeeper() {
-    TaskManagementModule::set_gatekeeper(RuntimeOrigin::root(), 1).unwrap();
+	TaskManagementModule::set_gatekeeper(RuntimeOrigin::root(), 1).unwrap();
 }
 
 #[test]

--- a/pallets/task-management/src/tests.rs
+++ b/pallets/task-management/src/tests.rs
@@ -51,9 +51,10 @@ fn it_works_for_task_scheduler() {
 		));
 
 		// Verify workers are registered
-        assert!(pallet_edge_connect::WorkerClusters::<Test>::contains_key((executor, 0)));
-        assert!(pallet_edge_connect::ExecutableWorkers::<Test>::contains_key((executor, 1)));
-
+		assert!(pallet_edge_connect::WorkerClusters::<Test>::contains_key((
+			executor, 0
+		)));
+		assert!(pallet_edge_connect::ExecutableWorkers::<Test>::contains_key((executor, 1)));
 
 		let task_kind_neurozk = TaskKind::NeuroZK;
 		let task_kind_infer = TaskKind::OpenInference;

--- a/pallets/task-management/src/tests.rs
+++ b/pallets/task-management/src/tests.rs
@@ -1,14 +1,11 @@
 use crate::{mock::*, Error};
-use crate::{NextTaskId, TaskAllocations, TaskOwners, TaskStatus, Tasks,ComputeAggregations};
-use frame_support::traits::Task;
+use crate::{NextTaskId, TaskStatus, Tasks,ComputeAggregations};
 use frame_support::{assert_noop, assert_ok};
 
-pub use cyborg_primitives::task::{TaskStatusType,TaskKind,TaskInfo};
+pub use cyborg_primitives::task::{TaskStatusType,TaskKind};
 pub use cyborg_primitives::worker::*;
 use frame_support::dispatch::{DispatchErrorWithPostInfo, PostDispatchInfo};
 use frame_support::BoundedVec;
-use sp_core::H256;
-use frame_system::Origin;
 use sp_std::convert::TryFrom;
 use frame_system::pallet_prelude::BlockNumberFor;
 
@@ -29,7 +26,6 @@ fn register_worker(
 	)
 }
 
-#[test]
 #[test]
 fn it_works_for_task_scheduler() {
 	new_test_ext().execute_with(|| {

--- a/pallets/task-management/src/weights.rs
+++ b/pallets/task-management/src/weights.rs
@@ -35,6 +35,10 @@ pub trait WeightInfo {
 	fn submit_completed_task(s: u32, ) -> Weight;
 	fn verify_completed_task(s: u32, ) -> Weight;
 	fn resolve_completed_task(s: u32, ) -> Weight;
+	fn confirm_task_reception() -> Weight;
+	fn stop_task_and_vacate_miner() -> Weight;
+	fn confirm_miner_vacation() -> Weight;
+	fn set_gatekeeper() -> Weight;
 }
 
 /// Weights for `pallet_task_management` using the Substrate node and recommended hardware.
@@ -112,6 +116,53 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+
+	fn confirm_task_reception() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 25_000_000 picoseconds.
+        Weight::from_parts(26_000_000, 3647)
+            .saturating_add(T::DbWeight::get().reads(3_u64))
+            .saturating_add(T::DbWeight::get().writes(3_u64))
+    }
+
+    /// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::ComputeAggregations` (r:1 w:1)
+    /// Proof: `TaskManagement::ComputeAggregations` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
+    fn stop_task_and_vacate_miner() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 20_000_000 picoseconds.
+        Weight::from_parts(21_000_000, 3647)
+            .saturating_add(T::DbWeight::get().reads(2_u64))
+            .saturating_add(T::DbWeight::get().writes(2_u64))
+    }
+
+    /// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    fn confirm_miner_vacation() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 15_000_000 picoseconds.
+        Weight::from_parts(16_000_000, 3647)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
+
+	/// Storage: `TaskManagement::GatekeeperAccount` (r:0 w:1)
+    /// Proof: `TaskManagement::GatekeeperAccount` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)
+    fn set_gatekeeper() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `0`
+        //  Estimated: `0`
+        // Minimum execution time: 10_000_000 picoseconds.
+        Weight::from_parts(10_000_000, 0)
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
 }
 
 // For backwards compatibility and tests.
@@ -188,4 +239,49 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+
+	fn confirm_task_reception() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 25_000_000 picoseconds.
+        Weight::from_parts(26_000_000, 3647)
+            .saturating_add(RocksDbWeight::get().reads(3_u64))
+            .saturating_add(RocksDbWeight::get().writes(3_u64))
+    }
+
+    /// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::ComputeAggregations` (r:1 w:1)
+    /// Proof: `TaskManagement::ComputeAggregations` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
+    fn stop_task_and_vacate_miner() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 20_000_000 picoseconds.
+        Weight::from_parts(21_000_000, 3647)
+            .saturating_add(RocksDbWeight::get().reads(2_u64))
+            .saturating_add(RocksDbWeight::get().writes(2_u64))
+    }
+
+    /// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    fn confirm_miner_vacation() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 15_000_000 picoseconds.
+        Weight::from_parts(16_000_000, 3647)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
+
+	fn set_gatekeeper() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `0`
+        //  Estimated: `0`
+        // Minimum execution time: 10_000_000 picoseconds.
+        Weight::from_parts(10_000_000, 0)
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
 }

--- a/pallets/zk-verifier/src/mock.rs
+++ b/pallets/zk-verifier/src/mock.rs
@@ -3,8 +3,8 @@ use frame_support::parameter_types;
 use frame_support::{derive_impl, weights::constants::RocksDbWeight};
 use frame_system::{mocking::MockBlock, GenesisConfig};
 use sp_runtime::{traits::ConstU64, BuildStorage};
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
-type Block = frame_system::mocking::MockBlock<Test>;
+// type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+// type Block = frame_system::mocking::MockBlock<Test>;
 
 // Configure a mock runtime to test the pallet.
 #[frame_support::runtime]
@@ -52,7 +52,7 @@ impl crate::Config for Test {
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut storage = GenesisConfig::<Test>::default().build_storage().unwrap();
+	let storage = GenesisConfig::<Test>::default().build_storage().unwrap();
 	let mut ext = sp_io::TestExternalities::new(storage);
 	ext.execute_with(|| frame_system::Pallet::<Test>::set_block_number(1));
 	ext

--- a/pallets/zk-verifier/src/tests.rs
+++ b/pallets/zk-verifier/src/tests.rs
@@ -37,7 +37,7 @@ use frame_support::{assert_err, assert_ok};
 
 const ALICE_ACCOUNT_ID: u64 = 2;
 const BOB_ACCOUNT_ID: u64 = 3;
-const taskId: TaskId = 0;
+const TASK_ID: TaskId = 0;
 
 #[test]
 fn test_setup_verification() {
@@ -46,13 +46,13 @@ fn test_setup_verification() {
 		// Call the function and verify it works correctly
 		assert_ok!(ZKVerifierModule::setup_verification(
 			RuntimeOrigin::none(),
-			taskId,
+			TASK_ID,
 			prepare_correct_public_inputs_json().as_bytes().into(),
 			vk.as_bytes().into()
 		));
 
 		// Updated storage check
-		let stored_vk = VerificationKeyStorage::<Test>::get(taskId);
+		let stored_vk = VerificationKeyStorage::<Test>::get(TASK_ID);
 		assert_eq!(stored_vk.is_some(), true);
 
 		// Verify the event was emitted
@@ -68,7 +68,7 @@ fn test_not_supported_vk_curve() {
 		assert_err!(
 			ZKVerifierModule::setup_verification(
 				RuntimeOrigin::none(),
-				taskId,
+				TASK_ID,
 				prepare_correct_public_inputs_json().as_bytes().into(),
 				vk.as_bytes().into()
 			),
@@ -86,7 +86,7 @@ fn test_not_supported_vk_protocol() {
 		assert_err!(
 			ZKVerifierModule::setup_verification(
 				RuntimeOrigin::none(),
-				taskId,
+				TASK_ID,
 				prepare_correct_public_inputs_json().as_bytes().into(),
 				vk.as_bytes().into()
 			),
@@ -104,7 +104,7 @@ fn test_too_long_verification_key() {
 		assert_err!(
 			ZKVerifierModule::setup_verification(
 				RuntimeOrigin::none(),
-				taskId,
+				TASK_ID,
 				prepare_correct_public_inputs_json().as_bytes().into(),
 				too_long_vk
 			),
@@ -120,7 +120,7 @@ fn test_too_long_public_inputs() {
 		assert_err!(
 			ZKVerifierModule::setup_verification(
 				RuntimeOrigin::none(),
-				taskId,
+				TASK_ID,
 				vec![0; (<Test as Config>::MaxPublicInputsLength::get() + 1) as usize],
 				prepare_vk_json("groth16", "bls12381", None)
 					.as_bytes()
@@ -138,7 +138,7 @@ fn test_public_inputs_mismatch() {
 		assert_err!(
 			ZKVerifierModule::setup_verification(
 				RuntimeOrigin::none(),
-				taskId,
+				TASK_ID,
 				prepare_empty_public_inputs_json().as_bytes().into(),
 				prepare_vk_json("groth16", "bls12381", None)
 					.as_bytes()
@@ -148,7 +148,7 @@ fn test_public_inputs_mismatch() {
 		);
 
 		// Check storage to ensure no key was set
-		assert!(!VerificationKeyStorage::<Test>::contains_key(taskId));
+		assert!(!VerificationKeyStorage::<Test>::contains_key(TASK_ID));
 		assert_eq!(zk_events().len(), 0);
 	});
 }
@@ -159,7 +159,7 @@ fn test_too_long_proof() {
 		assert_err!(
 			ZKVerifierModule::verify(
 				RuntimeOrigin::none(),
-				taskId,
+				TASK_ID,
 				vec![0; (<Test as Config>::MaxProofLength::get() + 1) as usize]
 			),
 			Error::<Test>::TooLongProof
@@ -174,7 +174,7 @@ fn test_not_supported_proof_protocol() {
 
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			ZKVerifierModule::verify(RuntimeOrigin::none(), taskId, proof.as_bytes().into()),
+			ZKVerifierModule::verify(RuntimeOrigin::none(), TASK_ID, proof.as_bytes().into()),
 			Error::<Test>::NotSupportedProtocol
 		);
 		assert_eq!(zk_events().len(), 0);
@@ -187,7 +187,7 @@ fn test_not_supported_proof_curve() {
 
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			ZKVerifierModule::verify(RuntimeOrigin::none(), taskId, proof.as_bytes().into()),
+			ZKVerifierModule::verify(RuntimeOrigin::none(), TASK_ID, proof.as_bytes().into()),
 			Error::<Test>::NotSupportedCurve
 		);
 		assert_eq!(zk_events().len(), 0);
@@ -198,7 +198,7 @@ fn test_not_supported_proof_curve() {
 fn test_empty_proof() {
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			ZKVerifierModule::verify(RuntimeOrigin::none(), taskId, Vec::new()),
+			ZKVerifierModule::verify(RuntimeOrigin::none(), TASK_ID, Vec::new()),
 			Error::<Test>::ProofIsEmpty
 		);
 		assert_eq!(zk_events().len(), 0);
@@ -211,7 +211,7 @@ fn test_verify_without_verification_key() {
 
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			ZKVerifierModule::verify(RuntimeOrigin::none(), taskId, proof.as_bytes().into()),
+			ZKVerifierModule::verify(RuntimeOrigin::none(), TASK_ID, proof.as_bytes().into()),
 			Error::<Test>::VerificationKeyIsNotSet
 		);
 		assert_eq!(zk_events().len(), 0);
@@ -226,13 +226,13 @@ fn test_verification_success() {
 
 		assert_ok!(ZKVerifierModule::setup_verification(
 			RuntimeOrigin::none(),
-			taskId,
+			TASK_ID,
 			prepare_correct_public_inputs_json().as_bytes().into(),
 			vk.as_bytes().into()
 		));
 		assert_ok!(ZKVerifierModule::verify(
 			RuntimeOrigin::signed(ALICE_ACCOUNT_ID),
-			taskId,
+			TASK_ID,
 			proof.as_bytes().into()
 		));
 
@@ -257,13 +257,13 @@ fn test_verification_failed() {
 
 		assert_ok!(ZKVerifierModule::setup_verification(
 			RuntimeOrigin::none(),
-			taskId,
+			TASK_ID,
 			prepare_incorrect_public_inputs_json().as_bytes().into(),
 			vk.as_bytes().into()
 		));
 		assert_ok!(ZKVerifierModule::verify(
 			RuntimeOrigin::signed(BOB_ACCOUNT_ID),
-			taskId,
+			TASK_ID,
 			proof.as_bytes().into()
 		));
 
@@ -283,12 +283,12 @@ fn test_could_not_create_proof() {
 
 		assert_ok!(ZKVerifierModule::setup_verification(
 			RuntimeOrigin::none(),
-			taskId,
+			TASK_ID,
 			prepare_correct_public_inputs_json().as_bytes().into(),
 			vk.as_bytes().into()
 		));
 		assert_err!(
-			ZKVerifierModule::verify(RuntimeOrigin::none(), taskId, proof.as_bytes().into()),
+			ZKVerifierModule::verify(RuntimeOrigin::none(), TASK_ID, proof.as_bytes().into()),
 			Error::<Test>::ProofCreationError
 		);
 
@@ -306,12 +306,12 @@ fn test_could_not_create_verification_key() {
 
 		assert_ok!(ZKVerifierModule::setup_verification(
 			RuntimeOrigin::none(),
-			taskId,
+			TASK_ID,
 			prepare_correct_public_inputs_json().as_bytes().into(),
 			vk.as_bytes().into()
 		));
 		assert_err!(
-			ZKVerifierModule::verify(RuntimeOrigin::none(), taskId, proof.as_bytes().into()),
+			ZKVerifierModule::verify(RuntimeOrigin::none(), TASK_ID, proof.as_bytes().into()),
 			Error::<Test>::VerificationKeyCreationError
 		);
 

--- a/primitives/src/payment.rs
+++ b/primitives/src/payment.rs
@@ -1,5 +1,5 @@
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::{pallet_prelude::ConstU32, sp_runtime::RuntimeDebug, BoundedVec};
+use frame_support::sp_runtime::RuntimeDebug;
 use scale_info::TypeInfo;
 
 // Struct to hold reward rates per resource type.

--- a/primitives/src/payment.rs
+++ b/primitives/src/payment.rs
@@ -4,8 +4,8 @@ use scale_info::TypeInfo;
 
 // Struct to hold reward rates per resource type.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-	pub struct RewardRates<Balance> {
-		pub cpu: Balance,
-		pub ram: Balance,
-		pub storage: Balance,
-	}
+pub struct RewardRates<Balance> {
+	pub cpu: Balance,
+	pub ram: Balance,
+	pub storage: Balance,
+}

--- a/primitives/src/task.rs
+++ b/primitives/src/task.rs
@@ -1,7 +1,6 @@
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{pallet_prelude::ConstU32, sp_runtime::RuntimeDebug, BoundedVec};
-use scale_info::{prelude::vec::Vec, TypeInfo};
-use sp_core::hash::H256;
+use scale_info::TypeInfo;
 
 pub type TaskId = u64;
 

--- a/primitives/src/task.rs
+++ b/primitives/src/task.rs
@@ -6,43 +6,41 @@ pub type TaskId = u64;
 
 #[derive(PartialEq, Eq, Clone, Decode, Encode, TypeInfo, Debug, MaxEncodedLen)]
 pub enum TaskStatusType {
-    /// Task has been assigned to a worker, but miner hasn't confirmed reception yet.
-    Assigned,
+	/// Task has been assigned to a worker, but miner hasn't confirmed reception yet.
+	Assigned,
 
-    /// Miner has confirmed reception, actively running task.
-    Running,
+	/// Miner has confirmed reception, actively running task.
+	Running,
 
-    /// Task was stopped forcibly (admin action or error).
-    Stopped,
+	/// Task was stopped forcibly (admin action or error).
+	Stopped,
 
-    /// Miner reset hardware after stopping task.
-    Vacated,
+	/// Miner reset hardware after stopping task.
+	Vacated,
 }
 
 /// Kinds of overall tasks at a logical level (business logic: inference vs zk proof).
 #[derive(PartialEq, Eq, Clone, Decode, Encode, TypeInfo, Debug, MaxEncodedLen)]
 pub enum TaskKind {
-    NeuroZK,         // A Zero-Knowledge Proof Generation task.
-    OpenInference,   // An AI Inference Task (normal).
+	NeuroZK,       // A Zero-Knowledge Proof Generation task.
+	OpenInference, // An AI Inference Task (normal).
 }
-
 
 ///Detailed information about a specific task.
 #[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub struct TaskInfo<AccountId, BlockNumber> {
-    pub task_owner: AccountId,                                 // Who scheduled the task.
-    pub create_block: BlockNumber,                             // Block when created.
-    pub metadata: BoundedVec<u8, ConstU32<500>>,                // Could be model link, executable link, etc.
-    pub zk_files_cid: Option<BoundedVec<u8, ConstU32<500>>>,    // Optional: ZK files if needed.
-    pub time_elapsed: Option<BlockNumber>,                     // Time consumed.
-    pub average_cpu_percentage_use: Option<u8>,                // CPU usage.
-    pub task_kind: TaskKind,                                   // New: Logical kind (NeuroZK or OpenInference).
-    pub result: Option<BoundedVec<u8, ConstU32<500>>>,          // Final result (optional).
-    pub compute_hours_deposit: Option<u32>,                    // Deposit paid upfront.
-    pub consume_compute_hours: Option<u32>,                    // How much was actually consumed.
-    pub task_status: TaskStatusType,                           // Current lifecycle status.
+	pub task_owner: AccountId,                   // Who scheduled the task.
+	pub create_block: BlockNumber,               // Block when created.
+	pub metadata: BoundedVec<u8, ConstU32<500>>, // Could be model link, executable link, etc.
+	pub zk_files_cid: Option<BoundedVec<u8, ConstU32<500>>>, // Optional: ZK files if needed.
+	pub time_elapsed: Option<BlockNumber>,       // Time consumed.
+	pub average_cpu_percentage_use: Option<u8>,  // CPU usage.
+	pub task_kind: TaskKind,                     // New: Logical kind (NeuroZK or OpenInference).
+	pub result: Option<BoundedVec<u8, ConstU32<500>>>, // Final result (optional).
+	pub compute_hours_deposit: Option<u32>,      // Deposit paid upfront.
+	pub consume_compute_hours: Option<u32>,      // How much was actually consumed.
+	pub task_status: TaskStatusType,             // Current lifecycle status.
 }
-
 
 // #[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 // pub struct VerificationHashes<AccountId> {

--- a/primitives/src/worker.rs
+++ b/primitives/src/worker.rs
@@ -16,8 +16,6 @@ pub type StorageBytes = u64;
 
 pub type CpuCores = u16;
 
-pub type WorkerReputation = u8;
-
 /// An enum that is used to differentiate between the different kinds of workers that are
 /// registered on the cyborg parachain. There is no differentiation between the ZK Worker and the
 /// Executable Worker, as the executable worker will be able to execute ZK Tasks
@@ -32,6 +30,7 @@ pub enum WorkerStatusType {
 	Active,
 	Busy,
 	Inactive,
+	Suspended,
 }
 
 #[derive(Default, PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
@@ -58,7 +57,7 @@ pub struct Worker<AccountId, BlockNumber, TimeStamp> {
 	pub owner: AccountId,
 	pub location: Location,
 	pub specs: WorkerSpecs,
-	pub reputation: WorkerReputation,
+	pub reputation: WorkerReputation<BlockNumber>,
 	pub start_block: BlockNumber,
 	pub status: WorkerStatusType,
 	pub status_last_updated: BlockNumber,
@@ -76,4 +75,23 @@ pub trait WorkerInfoHandler<AccountId, WorkerId, BlockNumber, TimeStamp> {
 		worker_type: &WorkerType,
 		worker: Worker<AccountId, BlockNumber, TimeStamp>,
 	);
+}
+
+#[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen, Copy)]
+pub struct WorkerReputation<BlockNumber> {
+	pub score: i32,
+	pub last_updated: Option<BlockNumber>,
+	pub violations: u32,
+	pub successful_tasks: u32,
+}
+
+impl<BlockNumber> Default for WorkerReputation<BlockNumber> {
+	fn default() -> Self {
+		Self {
+			score: 100,
+			last_updated: None,
+			violations: 0,
+			successful_tasks: 0,
+		}
+	}
 }

--- a/runtime/src/weights/pallet_edge_connect.rs
+++ b/runtime/src/weights/pallet_edge_connect.rs
@@ -32,8 +32,8 @@ pub trait WeightInfo {
 	fn register_worker() -> Weight;
 	fn remove_worker() -> Weight;
 	fn toggle_worker_visibility() -> Weight;
-	fn ban_miner() -> Weight;
-    fn update_reputation() -> Weight;
+
+	fn penalize_worker() -> Weight;
 }
 
 /// Weights for `pallet_edge_connect` using the Substrate node and recommended hardware.
@@ -75,28 +75,11 @@ impl<T: frame_system::Config> pallet_edge_connect::WeightInfo for SubstrateWeigh
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 
-	/// Storage: `EdgeConnect::BannedMiners` (r:0 w:1)
-    /// Proof: `EdgeConnect::BannedMiners` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
-    fn ban_miner() -> Weight {
-        // Proof Size summary in bytes:
-        //  Measured:  `0`
-        //  Estimated: `0`
-        // Minimum execution time: 8_000_000 picoseconds.
-        Weight::from_parts(9_000_000, 0)
-            .saturating_add(T::DbWeight::get().writes(1_u64))
-    }
-
-    /// Storage: `EdgeConnect::MinerReputation` (r:1 w:1)
-    /// Proof: `EdgeConnect::MinerReputation` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
-    fn update_reputation() -> Weight {
-        // Proof Size summary in bytes:
-        //  Measured:  `76`
-        //  Estimated: `3514`
-        // Minimum execution time: 10_000_000 picoseconds.
-        Weight::from_parts(11_000_000, 3514)
-            .saturating_add(T::DbWeight::get().reads(1_u64))
-            .saturating_add(T::DbWeight::get().writes(1_u64))
-    }
+	fn penalize_worker() -> Weight {
+		Weight::from_parts(10_000_000, 3688)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 }
 
 // For backwards compatibility and tests.
@@ -136,22 +119,11 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
-	fn ban_miner() -> Weight {
-        // Proof Size summary in bytes:
-        //  Measured:  `0`
-        //  Estimated: `0`
-        // Minimum execution time: 8_000_000 picoseconds.
-        Weight::from_parts(9_000_000, 0)
-            .saturating_add(RocksDbWeight::get().writes(1_u64))
-    }
+	
 
-    fn update_reputation() -> Weight {
-        // Proof Size summary in bytes:
-        //  Measured:  `76`
-        //  Estimated: `3514`
-        // Minimum execution time: 10_000_000 picoseconds.
-        Weight::from_parts(11_000_000, 3514)
-            .saturating_add(RocksDbWeight::get().reads(1_u64))
-            .saturating_add(RocksDbWeight::get().writes(1_u64))
-    }
+	fn penalize_worker() -> Weight {
+		Weight::from_parts(10_000_000, 3688)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
 }

--- a/runtime/src/weights/pallet_edge_connect.rs
+++ b/runtime/src/weights/pallet_edge_connect.rs
@@ -32,6 +32,8 @@ pub trait WeightInfo {
 	fn register_worker() -> Weight;
 	fn remove_worker() -> Weight;
 	fn toggle_worker_visibility() -> Weight;
+	fn ban_miner() -> Weight;
+    fn update_reputation() -> Weight;
 }
 
 /// Weights for `pallet_edge_connect` using the Substrate node and recommended hardware.
@@ -72,6 +74,29 @@ impl<T: frame_system::Config> pallet_edge_connect::WeightInfo for SubstrateWeigh
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+
+	/// Storage: `EdgeConnect::BannedMiners` (r:0 w:1)
+    /// Proof: `EdgeConnect::BannedMiners` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
+    fn ban_miner() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `0`
+        //  Estimated: `0`
+        // Minimum execution time: 8_000_000 picoseconds.
+        Weight::from_parts(9_000_000, 0)
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
+
+    /// Storage: `EdgeConnect::MinerReputation` (r:1 w:1)
+    /// Proof: `EdgeConnect::MinerReputation` (`max_values`: None, `max_size`: Some(49), added: 2524, mode: `MaxEncodedLen`)
+    fn update_reputation() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `76`
+        //  Estimated: `3514`
+        // Minimum execution time: 10_000_000 picoseconds.
+        Weight::from_parts(11_000_000, 3514)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
 }
 
 // For backwards compatibility and tests.
@@ -111,4 +136,22 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+	fn ban_miner() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `0`
+        //  Estimated: `0`
+        // Minimum execution time: 8_000_000 picoseconds.
+        Weight::from_parts(9_000_000, 0)
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
+
+    fn update_reputation() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `76`
+        //  Estimated: `3514`
+        // Minimum execution time: 10_000_000 picoseconds.
+        Weight::from_parts(11_000_000, 3514)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
 }

--- a/runtime/src/weights/pallet_payment.rs
+++ b/runtime/src/weights/pallet_payment.rs
@@ -107,6 +107,28 @@ impl<T: frame_system::Config> pallet_payment::WeightInfo for SubstrateWeight<T> 
 		Weight::from_parts(16_000_000_000, 0)
 			.saturating_add(T::DbWeight::get().reads_writes(10, 10)) 
 	}
+
+	fn set_reward_rates_for_miner() -> Weight {
+        Weight::from_parts(3_000_000_000, 0)
+            .saturating_add(T::DbWeight::get().writes(2_u64))
+    }
+
+    fn subscribe() -> Weight {
+        Weight::from_parts(5_000_000_000, 0)
+            .saturating_add(T::DbWeight::get().reads(3_u64))
+            .saturating_add(T::DbWeight::get().writes(2_u64))
+    }
+
+    fn add_hours() -> Weight {
+        Weight::from_parts(4_000_000_000, 0)
+            .saturating_add(T::DbWeight::get().reads(3_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
+
+    fn set_subscription_fee_per_hour() -> Weight {
+        Weight::from_parts(2_000_000_000, 0)
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
 }
 
 // For backwards compatibility and tests.

--- a/runtime/src/weights/pallet_task_management.rs
+++ b/runtime/src/weights/pallet_task_management.rs
@@ -33,6 +33,10 @@ pub trait WeightInfo {
 	fn submit_completed_task(s: u32, ) -> Weight;
 	fn verify_completed_task(s: u32, ) -> Weight;
 	fn resolve_completed_task(s: u32, ) -> Weight;
+	fn confirm_task_reception() -> Weight;
+    fn stop_task_and_vacate_miner() -> Weight;
+    fn confirm_miner_vacation() -> Weight;
+	fn set_gatekeeper() -> Weight; 
 }
 
 /// Weights for `pallet_task_management` using the Substrate node and recommended hardware.
@@ -114,6 +118,61 @@ impl<T: frame_system::Config> pallet_task_management::WeightInfo for SubstrateWe
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	
+/// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::TaskAllocations` (r:1 w:0)
+    /// Proof: `TaskManagement::TaskAllocations` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::TaskStatus` (r:1 w:1)
+    /// Proof: `TaskManagement::TaskStatus` (`max_values`: None, `max_size`: Some(17), added: 2492, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::ComputeAggregations` (r:0 w:1)
+    /// Proof: `TaskManagement::ComputeAggregations` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
+    fn confirm_task_reception() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 25_000_000 picoseconds.
+        Weight::from_parts(26_000_000, 3647)
+            .saturating_add(T::DbWeight::get().reads(3_u64))
+            .saturating_add(T::DbWeight::get().writes(3_u64))
+    }
+
+    /// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::ComputeAggregations` (r:1 w:1)
+    /// Proof: `TaskManagement::ComputeAggregations` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
+    fn stop_task_and_vacate_miner() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 20_000_000 picoseconds.
+        Weight::from_parts(21_000_000, 3647)
+            .saturating_add(T::DbWeight::get().reads(2_u64))
+            .saturating_add(T::DbWeight::get().writes(2_u64))
+    }
+
+    /// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    fn confirm_miner_vacation() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 15_000_000 picoseconds.
+        Weight::from_parts(16_000_000, 3647)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
+
+	/// Storage: `TaskManagement::GatekeeperAccount` (r:0 w:1)
+    /// Proof: `TaskManagement::GatekeeperAccount` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)
+    fn set_gatekeeper() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `0`
+        //  Estimated: `0`
+        // Minimum execution time: 10_000_000 picoseconds.
+        Weight::from_parts(10_000_000, 0)
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
 }
 
 // For backwards compatibility and tests.
@@ -194,4 +253,57 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+
+	/// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::TaskAllocations` (r:1 w:0)
+    /// Proof: `TaskManagement::TaskAllocations` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::TaskStatus` (r:1 w:1)
+    /// Proof: `TaskManagement::TaskStatus` (`max_values`: None, `max_size`: Some(17), added: 2492, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::ComputeAggregations` (r:0 w:1)
+    /// Proof: `TaskManagement::ComputeAggregations` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
+    fn confirm_task_reception() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 25_000_000 picoseconds.
+        Weight::from_parts(26_000_000, 3647)
+            .saturating_add(RocksDbWeight::get().reads(3_u64))
+            .saturating_add(RocksDbWeight::get().writes(3_u64))
+    }
+
+    /// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::ComputeAggregations` (r:1 w:1)
+    /// Proof: `TaskManagement::ComputeAggregations` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
+    fn stop_task_and_vacate_miner() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 20_000_000 picoseconds.
+        Weight::from_parts(21_000_000, 3647)
+            .saturating_add(RocksDbWeight::get().reads(2_u64))
+            .saturating_add(RocksDbWeight::get().writes(2_u64))
+    }
+
+    /// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    fn confirm_miner_vacation() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `361`
+        //  Estimated: `3647`
+        // Minimum execution time: 15_000_000 picoseconds.
+        Weight::from_parts(16_000_000, 3647)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
+
+	fn set_gatekeeper() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `0`
+        //  Estimated: `0`
+        // Minimum execution time: 10_000_000 picoseconds.
+        Weight::from_parts(10_000_000, 0)
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
 }


### PR DESCRIPTION
Feeless Task Scheduling for Gatekeeper:

- Added Gatekeeper type to pallet_task_management config

- Modified task_scheduler to be feeless only for the gatekeeper account

- Implemented gatekeeper account in runtime using parameter_types!

Miner-Only Functions with Feeless Execution:

- Added miner checks to all miner-called functions (submit_completed_task, verify_completed_task, resolve_completed_task)

- Made all miner functions feeless (Pays::No)

- Ensured only registered miners can call these functions

Runtime Configuration:

- Added gatekeeper account configuration

- Updated mock runtime for testing

Edge-connect:
- Added new events for when a worker is penalized or suspended.
- Added helper function to check worker's status.
- Added extrinsic to penalize workers.

Worker:
- Updated `WorkerReputation`

Task-management: 
- Modified task_scheduler to check if worker's status and reputation.
- Added a check for worker's existence.
- Added check_rate_limit logic.

