### PR TITLE
feat(edge-connect): Restructure inventory with location and owner indices

### DIFF
--- a/pallets/edge-connect/src/benchmarking.rs
+++ b/pallets/edge-connect/src/benchmarking.rs
@@ -78,6 +78,14 @@ fn set_initial_benchmark_data<T: Config>() {
 
 			// Insert the worker into the WorkerClusters map
 			WorkerClusters::<T>::insert((creator.clone(), worker_id), worker);
+
+			WorkersByLocation::<T>::append(
+				worker_location.latitude,
+				worker_location.longitude,
+				(creator.clone(), worker_id)
+			);
+			
+			WorkersByOwner::<T>::append(creator.clone(), worker_id);
 		}
 	}
 }

--- a/pallets/edge-connect/src/tests.rs
+++ b/pallets/edge-connect/src/tests.rs
@@ -465,6 +465,33 @@ fn it_fails_for_changing_visibility_on_nonexistant_worker() {
 	})
 }
 
+#[test]
+fn test_workers_by_location() {
+	new_test_ext().execute_with(|| {
+		let alice = 0;
+		let domain = BoundedVec::try_from(b"test.com".to_vec()).unwrap();
+		let latitude = 1000;
+		let longitude = 2000;
+
+		// Register worker
+		assert_ok!(EdgeConnectModule::register_worker(
+			RuntimeOrigin::signed(alice),
+			WorkerType::Docker,
+			domain.clone(),
+			latitude,
+			longitude,
+			1000,
+			1000,
+			1
+		));
+
+		// Check location index
+		let workers = EdgeConnectModule::get_workers_by_location(latitude, longitude);
+		assert_eq!(workers.len(), 1);
+		assert_eq!(workers[0], (alice, 0));
+	});
+}
+
 /*
 
 	let domain_str = "some_api_domain.com";


### PR DESCRIPTION
This PR restructures the edge-connect pallet's inventory system to:

- Add efficient indexing of workers by location (latitude/longitude).

- Add efficient indexing of workers by owner account.

- Maintain consistency between primary storage and indices.

- Provide new helper functions for location-based queries.

- Improve worker retrieval performance for location-aware operations.