### PR TITLE
feat: Implement comprehensive miner suspension system with automatic penalties and manual controls

### DIFF
--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -23,6 +23,7 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 	use pallet_timestamp as timestamp;
 	use scale_info::prelude::vec::Vec;
+	use frame_support::sp_runtime::Saturating;
 
 	// The `Config` trait defines the configuration for this pallet. It specifies the types and parameters
 	// that the pallet depends on and provides flexibility to the runtime in how it implements these
@@ -58,6 +59,16 @@ pub mod pallet {
 	#[pallet::getter(fn account_workers)]
 	pub type AccountWorkers<T: Config> =
 		StorageMap<_, Twox64Concat, T::AccountId, WorkerId, OptionQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn suspended_workers)]
+	pub type SuspendedWorkers<T: Config> = StorageMap<
+		_,
+		Twox64Concat,
+		(T::AccountId, WorkerId),
+		(BlockNumberFor<T>, SuspensionReason),
+		OptionQuery,
+	>;
 
 	/// Worker Cluster information, Storage map to keep track of detailed worker cluster information for each (account ID, worker ID) pair.
 	#[pallet::storage]
@@ -127,6 +138,21 @@ pub mod pallet {
 			worker: (T::AccountId, WorkerId),
 			until_block: BlockNumberFor<T>,
 		},
+
+		/// Event emitted when a worker is put under review
+		WorkerUnderReview {
+			worker: (T::AccountId, WorkerId),
+			reason: SuspensionReason,
+		},
+
+		/// Event emitted when a worker is banned
+		WorkerBanned {
+			worker: (T::AccountId, WorkerId),
+			reason: SuspensionReason,
+		},
+
+		/// Event emitted when a worker is unsuspended
+		WorkerUnsuspended { worker: (T::AccountId, WorkerId) },
 	}
 
 	#[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
@@ -359,9 +385,54 @@ pub mod pallet {
 		) -> DispatchResult {
 			ensure_root(origin)?;
 
-			Self::apply_penalty(&(worker_owner, worker_id), worker_type, penalty, reason)?;
+			Self::apply_penalty(&(worker_owner, worker_id), &worker_type, penalty, reason)?;
 
 			Ok(())
+		}
+
+		/// Manually suspend a worker (root only)
+		#[pallet::call_index(4)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::suspend_worker())]
+		pub fn suspend_worker(
+			origin: OriginFor<T>,
+			worker_owner: T::AccountId,
+			worker_id: WorkerId,
+			worker_type: WorkerType,
+			blocks: BlockNumberFor<T>,
+			reason: SuspensionReason,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+
+			Self::suspend_workers(&(worker_owner, worker_id), &worker_type, blocks, reason)
+		}
+
+		/// Manually ban a worker (root only)
+		#[pallet::call_index(5)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::ban_worker())]
+		pub fn ban_worker(
+			origin: OriginFor<T>,
+			worker_owner: T::AccountId,
+			worker_id: WorkerId,
+			worker_type: WorkerType,
+			reason: SuspensionReason,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+
+			Self::ban_workers(&(worker_owner, worker_id), worker_type, reason)
+		}
+
+		/// Lift suspension from a worker (root only)
+		#[pallet::call_index(6)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::unsuspend_worker())]
+		pub fn unsuspend_worker(
+			origin: OriginFor<T>,
+			worker_owner: T::AccountId,
+			worker_id: WorkerId,
+			worker_type: WorkerType,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+	
+			Self::lift_suspension(&(worker_owner, worker_id), &worker_type)
 		}
 	}
 
@@ -392,7 +463,7 @@ pub mod pallet {
 		/// Apply penalty to a worker's reputation
 		fn apply_penalty(
 			worker_key: &(T::AccountId, WorkerId),
-			worker_type: WorkerType,
+			worker_type: &WorkerType,
 			penalty: i32,
 			reason: PenaltyReason,
 		) -> DispatchResult {
@@ -407,17 +478,37 @@ pub mod pallet {
 			worker.reputation.violations += 1;
 			worker.reputation.last_updated = Some(<frame_system::Pallet<T>>::block_number());
 
-			// If reputation drops below threshold, suspend the worker
+			// Automatic suspension triggers
 			if worker.reputation.score < 30 {
-				worker.status = WorkerStatusType::Suspended;
-				// Suspend for 1000 blocks (~4 hours at 6s/block)
-				worker.status_last_updated = <frame_system::Pallet<T>>::block_number() + 1000u32.into();
+				// Severe penalty - suspend for 1000 blocks (~4 hours at 6s/block)
+				Self::suspend_workers(
+					worker_key,
+					&worker_type.clone(),
+					1000u32.into(),
+					SuspensionReason::ReputationThreshold,
+				)?;
+			} else if worker.reputation.score < 50 {
+				// Moderate penalty - put under review
+				Self::put_worker_under_review(
+					worker_key,
+					&worker_type.clone(),
+					SuspensionReason::ReputationThreshold,
+				)?;
+			} else if worker.reputation.violations > 10 {
+				// Too many violations - review
+				Self::put_worker_under_review(
+					worker_key,
+					&worker_type.clone(),
+					SuspensionReason::RepeatedTaskFailures,
+				)?;
 			}
 
-			// Update storage
-			match worker_type {
-				WorkerType::Docker => WorkerClusters::<T>::insert(worker_key, worker),
-				WorkerType::Executable => ExecutableWorkers::<T>::insert(worker_key, worker),
+			// Update storage if not suspended
+			if worker.status != WorkerStatusType::Suspended {
+				match worker_type {
+					WorkerType::Docker => WorkerClusters::<T>::insert(worker_key, worker),
+					WorkerType::Executable => ExecutableWorkers::<T>::insert(worker_key, worker),
+				}
 			}
 
 			Self::deposit_event(Event::WorkerPenalized {
@@ -460,6 +551,129 @@ pub mod pallet {
 				return Err(Error::<T>::InsufficientReputation.into());
 			}
 
+			Ok(())
+		}
+
+		/// Suspend a worker with a specific reason and duration
+		fn suspend_workers(
+			worker_key: &(T::AccountId, WorkerId),
+			worker_type: &WorkerType,
+			blocks: BlockNumberFor<T>,
+			reason: SuspensionReason,
+		) -> DispatchResult {
+			let mut worker = match worker_type {
+				WorkerType::Docker => WorkerClusters::<T>::get(worker_key),
+				WorkerType::Executable => ExecutableWorkers::<T>::get(worker_key),
+			}
+			.ok_or(Error::<T>::WorkerDoesNotExist)?;
+
+			let current_block = <frame_system::Pallet<T>>::block_number();
+			let suspension_end = current_block.saturating_add(blocks);
+
+			// Update worker status
+			worker.status = WorkerStatusType::Suspended;
+			worker.status_last_updated = suspension_end;
+			worker.reputation.suspension_count += 1;
+
+			// Update storage
+			match worker_type {
+				WorkerType::Docker => WorkerClusters::<T>::insert(worker_key, worker),
+				WorkerType::Executable => ExecutableWorkers::<T>::insert(worker_key, worker),
+			}
+
+			// Record suspension
+			SuspendedWorkers::<T>::insert(worker_key, (suspension_end, reason.clone()));
+
+			Self::deposit_event(Event::WorkerSuspended {
+				worker: worker_key.clone(),
+				until_block: suspension_end,
+			});
+
+			Ok(())
+		}
+
+		/// Put worker under review
+		fn put_worker_under_review(
+			worker_key: &(T::AccountId, WorkerId),
+			worker_type: &WorkerType,
+			reason: SuspensionReason,
+		) -> DispatchResult {
+			let mut worker = match worker_type {
+				WorkerType::Docker => WorkerClusters::<T>::get(worker_key),
+				WorkerType::Executable => ExecutableWorkers::<T>::get(worker_key),
+			}
+			.ok_or(Error::<T>::WorkerDoesNotExist)?;
+
+			worker.status = WorkerStatusType::Inactive; // Can't accept new tasks
+			worker.reputation.review_count += 1;
+
+			// Update storage
+			match worker_type {
+				WorkerType::Docker => WorkerClusters::<T>::insert(worker_key, worker),
+				WorkerType::Executable => ExecutableWorkers::<T>::insert(worker_key, worker),
+			}
+
+			Self::deposit_event(Event::WorkerUnderReview {
+				worker: worker_key.clone(),
+				reason,
+			});
+
+			Ok(())
+		}
+
+		/// Ban a worker permanently
+		fn ban_workers(
+			worker_key: &(T::AccountId, WorkerId),
+			worker_type: WorkerType,
+			reason: SuspensionReason,
+		) -> DispatchResult {
+			// Remove from active workers
+			match worker_type {
+				WorkerType::Docker => WorkerClusters::<T>::remove(worker_key),
+				WorkerType::Executable => ExecutableWorkers::<T>::remove(worker_key),
+			}
+
+			Self::deposit_event(Event::WorkerBanned {
+				worker: worker_key.clone(),
+				reason,
+			});
+
+			Ok(())
+		}
+
+		/// Lift suspension from a worker
+		fn lift_suspension(
+			worker_key: &(T::AccountId, WorkerId),
+			worker_type: &WorkerType,
+		) -> DispatchResult {
+			let mut worker = match worker_type {
+				WorkerType::Docker => WorkerClusters::<T>::get(worker_key),
+				WorkerType::Executable => ExecutableWorkers::<T>::get(worker_key),
+			}
+			.ok_or(Error::<T>::WorkerDoesNotExist)?;
+	
+			// Only proceed if actually suspended
+			if worker.status != WorkerStatusType::Suspended {
+				return Ok(());
+			}
+	
+			// Update worker status
+			worker.status = WorkerStatusType::Inactive;
+			worker.status_last_updated = <frame_system::Pallet<T>>::block_number();
+	
+			// Update storage
+			match worker_type {
+				WorkerType::Docker => WorkerClusters::<T>::insert(worker_key, worker),
+				WorkerType::Executable => ExecutableWorkers::<T>::insert(worker_key, worker),
+			}
+	
+			// Remove from suspended workers
+			SuspendedWorkers::<T>::remove(worker_key);
+	
+			Self::deposit_event(Event::WorkerUnsuspended {
+				worker: worker_key.clone(),
+			});
+	
 			Ok(())
 		}
 	}

--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -19,11 +19,11 @@ pub use cyborg_primitives::worker::*;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
+	use frame_support::sp_runtime::Saturating;
 	use frame_support::{dispatch::DispatchResultWithPostInfo, pallet_prelude::*};
 	use frame_system::pallet_prelude::*;
 	use pallet_timestamp as timestamp;
 	use scale_info::prelude::vec::Vec;
-	use frame_support::sp_runtime::Saturating;
 
 	// The `Config` trait defines the configuration for this pallet. It specifies the types and parameters
 	// that the pallet depends on and provides flexibility to the runtime in how it implements these
@@ -431,7 +431,7 @@ pub mod pallet {
 			worker_type: WorkerType,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-	
+
 			Self::lift_suspension(&(worker_owner, worker_id), &worker_type)
 		}
 	}
@@ -651,29 +651,29 @@ pub mod pallet {
 				WorkerType::Executable => ExecutableWorkers::<T>::get(worker_key),
 			}
 			.ok_or(Error::<T>::WorkerDoesNotExist)?;
-	
+
 			// Only proceed if actually suspended
 			if worker.status != WorkerStatusType::Suspended {
 				return Ok(());
 			}
-	
+
 			// Update worker status
 			worker.status = WorkerStatusType::Inactive;
 			worker.status_last_updated = <frame_system::Pallet<T>>::block_number();
-	
+
 			// Update storage
 			match worker_type {
 				WorkerType::Docker => WorkerClusters::<T>::insert(worker_key, worker),
 				WorkerType::Executable => ExecutableWorkers::<T>::insert(worker_key, worker),
 			}
-	
+
 			// Remove from suspended workers
 			SuspendedWorkers::<T>::remove(worker_key);
-	
+
 			Self::deposit_event(Event::WorkerUnsuspended {
 				worker: worker_key.clone(),
 			});
-	
+
 			Ok(())
 		}
 	}

--- a/pallets/edge-connect/src/weights.rs
+++ b/pallets/edge-connect/src/weights.rs
@@ -35,6 +35,9 @@ pub trait WeightInfo {
 	fn remove_worker() -> Weight;
     fn toggle_worker_visibility() -> Weight;
 	fn penalize_worker() -> Weight;
+	fn suspend_worker() -> Weight;
+    fn ban_worker() -> Weight;
+    fn unsuspend_worker() -> Weight;
 }
 
 /// Weights for `pallet_edge_connect` using the Substrate node and recommended hardware.
@@ -81,6 +84,24 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+
+	fn suspend_worker() -> Weight {
+        Weight::from_parts(15_000_000, 3688)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(2_u64))
+    }
+    
+    fn ban_worker() -> Weight {
+        Weight::from_parts(10_000_000, 3688)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
+    
+    fn unsuspend_worker() -> Weight {
+        Weight::from_parts(10_000_000, 3688)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
 }
 
 // For backwards compatibility and tests.
@@ -125,5 +146,23 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+
+	fn suspend_worker() -> Weight {
+        Weight::from_parts(15_000_000, 3688)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(2_u64))
+    }
+    
+    fn ban_worker() -> Weight {
+        Weight::from_parts(10_000_000, 3688)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
+    
+    fn unsuspend_worker() -> Weight {
+        Weight::from_parts(10_000_000, 3688)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
 
 }

--- a/primitives/src/worker.rs
+++ b/primitives/src/worker.rs
@@ -83,6 +83,8 @@ pub struct WorkerReputation<BlockNumber> {
 	pub last_updated: Option<BlockNumber>,
 	pub violations: u32,
 	pub successful_tasks: u32,
+	pub suspension_count: u32,
+	pub review_count: u32,
 }
 
 impl<BlockNumber> Default for WorkerReputation<BlockNumber> {
@@ -92,6 +94,24 @@ impl<BlockNumber> Default for WorkerReputation<BlockNumber> {
 			last_updated: None,
 			violations: 0,
 			successful_tasks: 0,
+			suspension_count: 0,
+			review_count: 0,
 		}
 	}
+}
+
+#[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub enum SuspicionLevel {
+	Review,
+	Suspension,
+	Ban,
+}
+
+#[derive(PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub enum SuspensionReason {
+	RepeatedTaskFailures,
+	SpamBehavior,
+	MaliciousActivity,
+	ReputationThreshold,
+	ManualOverride,
 }

--- a/runtime/src/weights/pallet_edge_connect.rs
+++ b/runtime/src/weights/pallet_edge_connect.rs
@@ -32,8 +32,10 @@ pub trait WeightInfo {
 	fn register_worker() -> Weight;
 	fn remove_worker() -> Weight;
 	fn toggle_worker_visibility() -> Weight;
-
 	fn penalize_worker() -> Weight;
+	fn suspend_worker() -> Weight;
+    fn ban_worker() -> Weight;
+    fn unsuspend_worker() -> Weight;
 }
 
 /// Weights for `pallet_edge_connect` using the Substrate node and recommended hardware.
@@ -80,6 +82,24 @@ impl<T: frame_system::Config> pallet_edge_connect::WeightInfo for SubstrateWeigh
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+
+	fn suspend_worker() -> Weight {
+        Weight::from_parts(15_000_000, 3688)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(2_u64))
+    }
+    
+    fn ban_worker() -> Weight {
+        Weight::from_parts(10_000_000, 3688)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
+    
+    fn unsuspend_worker() -> Weight {
+        Weight::from_parts(10_000_000, 3688)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
 }
 
 // For backwards compatibility and tests.
@@ -126,4 +146,22 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+
+	fn suspend_worker() -> Weight {
+        Weight::from_parts(15_000_000, 3688)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(2_u64))
+    }
+    
+    fn ban_worker() -> Weight {
+        Weight::from_parts(10_000_000, 3688)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
+    
+    fn unsuspend_worker() -> Weight {
+        Weight::from_parts(10_000_000, 3688)
+            .saturating_add(RocksDbWeight::get().reads(1_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
 }


### PR DESCRIPTION
This PR implements a robust miner suspension system for the Edge Connect pallet that:

Defines Suspension Levels:

- Review status for minor issues (reputation 30-50)

- Temporary suspension for moderate issues (reputation <30)

- Permanent bans for severe violations (manual action)

Automatic Triggers:

- Workers are automatically put under review when reputation drops below 50

- Workers are automatically suspended when reputation drops below 30

- Workers with excessive violations (>10) are automatically reviewed

Manual Controls:

- Root/admin can manually suspend workers for custom durations

- Root/admin can permanently ban workers

- New extrinsic to lift suspensions early

Transparency:

- Clear event emissions for all actions

- Suspension reasons recorded on-chain

- Automatic unsuspension when periods expire

User Impact:

- Review status prevents new tasks but allows completion of existing ones

- Suspension pauses all worker activity temporarily

- Banning permanently removes worker functionality

