### PR TITLE
feat: Add task confirmation timeout with miner penalties

### DIFF
--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -497,7 +497,7 @@ pub mod pallet {
 		}
 
 		/// Apply penalty to a worker's reputation
-		fn apply_penalty(
+		pub fn apply_penalty(
 			worker_key: &(T::AccountId, WorkerId),
 			worker_type: &WorkerType,
 			penalty: i32,
@@ -591,7 +591,7 @@ pub mod pallet {
 		}
 
 		/// Suspend a worker with a specific reason and duration
-		fn suspend_workers(
+		pub fn suspend_workers(
 			worker_key: &(T::AccountId, WorkerId),
 			worker_type: &WorkerType,
 			blocks: BlockNumberFor<T>,

--- a/pallets/neuro-zk/src/mock.rs
+++ b/pallets/neuro-zk/src/mock.rs
@@ -84,6 +84,11 @@ impl pallet_edge_connect::Config for Test {
 impl pallet_task_management::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
+	type TaskConfirmationTimeout = TaskConfirmationTimeout;
+}
+
+parameter_types! {
+	pub const TaskConfirmationTimeout: u64 = 75; // ~7.5 minutes at 6s/block
 }
 
 impl pallet_payment::Config for Test {

--- a/pallets/task-management/src/mock.rs
+++ b/pallets/task-management/src/mock.rs
@@ -54,6 +54,11 @@ impl frame_system::Config for Test {
 impl pallet_task_management::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
+	type TaskConfirmationTimeout = TaskConfirmationTimeout;
+}
+
+parameter_types! {
+	pub const TaskConfirmationTimeout: u64 = 75; // ~7.5 minutes at 6s/block
 }
 
 impl pallet_edge_connect::Config for Test {

--- a/primitives/src/worker.rs
+++ b/primitives/src/worker.rs
@@ -130,4 +130,5 @@ pub enum SuspensionReason {
 	MaliciousActivity,
 	ReputationThreshold,
 	ManualOverride,
+	TaskConfirmationTimeout,
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -360,6 +360,7 @@ impl pallet_edge_connect::Config for Runtime {
 impl pallet_task_management::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = weights::pallet_task_management::SubstrateWeight<Runtime>;
+	type TaskConfirmationTimeout = ConstU32<75>;
 }
 
 parameter_types! {


### PR DESCRIPTION
- Added block-based timeout for task reception confirmation

- Miners that don't confirm within 75 blocks (~7.5 minutes) are penalized and suspended

- Added storage to track task assignment time

- Implemented regular checks via on_initialize hook

- Allows tasks to be reassigned if the miner fails to confirm

