### PR TITLE
feat(edge-connect): Add busy worker tracking and conditional status updates

### DIFF
--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -768,8 +768,8 @@ pub mod pallet {
 			worker_type: &WorkerType,
 			desired_status: WorkerStatusType,
 		) -> Result<bool, Error<T>> {
-			// Don't allow setting to active if worker is busy
-			if desired_status == WorkerStatusType::Active && BusyWorkers::<T>::contains_key(worker_key) {
+			// Don't allow any status changes if worker is busy
+			if BusyWorkers::<T>::contains_key(worker_key) {
 				return Ok(false);
 			}
 

--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -90,6 +90,11 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
+	#[pallet::storage]
+	#[pallet::getter(fn busy_workers)]
+	pub type BusyWorkers<T: Config> =
+		StorageMap<_, Twox64Concat, (T::AccountId, WorkerId), bool, ValueQuery>;
+
 	/// The `Event` enum contains the various events that can be emitted by this pallet.
 	/// Events are emitted when significant actions or state changes happen in the pallet.
 	#[pallet::event]
@@ -198,6 +203,8 @@ pub mod pallet {
 		WorkerSuspended,
 		/// Worker reputation is too low
 		InsufficientReputation,
+		/// Error indicating that the worker is busy and cannot be set to active
+		WorkerIsBusy,
 	}
 
 	// This block defines the dispatchable functions (calls) for the pallet.
@@ -363,6 +370,12 @@ pub mod pallet {
 			visibility: bool,
 		) -> DispatchResultWithPostInfo {
 			let creator = ensure_signed(origin)?;
+
+			let worker_key = (creator.clone(), worker_id);
+
+			if visibility && BusyWorkers::<T>::contains_key(worker_key) {
+				return Err(Error::<T>::WorkerIsBusy.into());
+			}
 			let worker_status = if visibility {
 				WorkerStatusType::Active
 			} else {
@@ -469,6 +482,27 @@ pub mod pallet {
 			ensure_root(origin)?;
 
 			Self::lift_suspension(&(worker_owner, worker_id), &worker_type)
+		}
+
+		#[pallet::call_index(7)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::toggle_worker_visibility())]
+		pub fn set_worker_busy_status(
+			origin: OriginFor<T>,
+			worker_type: WorkerType,
+			worker_id: WorkerId,
+			is_busy: bool,
+		) -> DispatchResultWithPostInfo {
+			let creator = ensure_signed(origin)?;
+			let worker_key = (creator.clone(), worker_id);
+
+			// Update busy status
+			if is_busy {
+				BusyWorkers::<T>::insert(worker_key, true);
+			} else {
+				BusyWorkers::<T>::remove(worker_key);
+			}
+
+			Ok(().into())
 		}
 	}
 
@@ -711,6 +745,46 @@ pub mod pallet {
 			});
 
 			Ok(())
+		}
+
+		/// Helper function for oracle feeders to safely update worker status
+		/// Returns true if status was updated, false if worker is busy
+		pub fn safe_update_worker_status(
+			worker_key: &(T::AccountId, WorkerId),
+			worker_type: &WorkerType,
+			desired_status: WorkerStatusType,
+		) -> Result<bool, Error<T>> {
+			// Don't allow setting to active if worker is busy
+			if desired_status == WorkerStatusType::Active && BusyWorkers::<T>::contains_key(worker_key) {
+				return Ok(false);
+			}
+
+			let mut worker = match worker_type {
+				WorkerType::Docker => WorkerClusters::<T>::get(worker_key),
+				WorkerType::Executable => ExecutableWorkers::<T>::get(worker_key),
+			}
+			.ok_or(Error::<T>::WorkerDoesNotExist)?;
+
+			// Only update if status is actually changing
+			if worker.status == desired_status {
+				return Ok(false);
+			}
+
+			worker.status = desired_status.clone();
+			worker.last_status_check = timestamp::Pallet::<T>::get();
+
+			match worker_type {
+				WorkerType::Docker => WorkerClusters::<T>::insert(worker_key, worker),
+				WorkerType::Executable => ExecutableWorkers::<T>::insert(worker_key, worker),
+			}
+
+			Self::deposit_event(Event::WorkerStatusUpdated {
+				creator: worker_key.0.clone(),
+				worker_id: worker_key.1,
+				worker_status: desired_status,
+			});
+
+			Ok(true)
 		}
 	}
 

--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -373,6 +373,7 @@ pub mod pallet {
 
 			let worker_key = (creator.clone(), worker_id);
 
+			// Prevent setting to active if worker is busy
 			if visibility && BusyWorkers::<T>::contains_key(worker_key) {
 				return Err(Error::<T>::WorkerIsBusy.into());
 			}
@@ -483,30 +484,43 @@ pub mod pallet {
 
 			Self::lift_suspension(&(worker_owner, worker_id), &worker_type)
 		}
+	}
 
-		#[pallet::call_index(7)]
-		#[pallet::weight(<T as pallet::Config>::WeightInfo::toggle_worker_visibility())]
-		pub fn set_worker_busy_status(
-			origin: OriginFor<T>,
+	impl<T: Config> Pallet<T> {
+		pub fn is_worker_busy(worker_key: &(T::AccountId, WorkerId)) -> bool {
+			BusyWorkers::<T>::contains_key(worker_key)
+		}
+
+		pub fn set_worker_busy_status_internal(
+			worker_key: &(T::AccountId, WorkerId),
 			worker_type: WorkerType,
-			worker_id: WorkerId,
 			is_busy: bool,
-		) -> DispatchResultWithPostInfo {
-			let creator = ensure_signed(origin)?;
-			let worker_key = (creator.clone(), worker_id);
-
+		) -> DispatchResult {
 			// Update busy status
 			if is_busy {
 				BusyWorkers::<T>::insert(worker_key, true);
+
+				// If worker is currently active, set to inactive
+				if let Some(mut worker) = Self::get_worker_cluster(worker_key, &worker_type) {
+					if worker.status == WorkerStatusType::Active {
+						worker.status = WorkerStatusType::Inactive;
+						worker.last_status_check = timestamp::Pallet::<T>::get();
+
+						Self::update_worker_cluster(worker_key, &worker_type, worker);
+
+						Self::deposit_event(Event::WorkerStatusUpdated {
+							creator: worker_key.0.clone(),
+							worker_id: worker_key.1,
+							worker_status: WorkerStatusType::Inactive,
+						});
+					}
+				}
 			} else {
 				BusyWorkers::<T>::remove(worker_key);
 			}
 
-			Ok(().into())
+			Ok(())
 		}
-	}
-
-	impl<T: Config> Pallet<T> {
 		// Helper Function to retrieve all active workers from storage.
 		// Filters workers based on their status (active or inactive).
 		pub fn get_active_workers() -> Option<

--- a/pallets/task-management/src/lib.rs
+++ b/pallets/task-management/src/lib.rs
@@ -313,7 +313,7 @@ where
 		/// Allowed only if task is still `Assigned`.
 		/// Changes task state to `Running` and starts aggregation of resource usage.
 		#[pallet::call_index(1)]
-		#[pallet::weight(<T as pallet::Config>::WeightInfo::confirm_task_reception())]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::confirm_task_reception())]
         pub fn confirm_task_reception(origin: OriginFor<T>, task_id: TaskId) -> DispatchResult {
             let who = ensure_signed(origin)?;
 
@@ -335,21 +335,24 @@ where
                 Error::<T>::RequireAssignedTask
             );
 
-            task_info.task_status = TaskStatusType::Running;
-            TaskStatus::<T>::insert(task_id, TaskStatusType::Running);
-            Tasks::<T>::insert(task_id, task_info);
+          // Set worker as busy using the new helper function
+          Self::update_worker_busy_status(task_id, true)?;
 
-            ComputeAggregations::<T>::insert(
+           task_info.task_status = TaskStatusType::Running;
+           TaskStatus::<T>::insert(task_id, TaskStatusType::Running);
+           Tasks::<T>::insert(task_id, task_info);
+
+           ComputeAggregations::<T>::insert(
                 task_id,
-                (
-                    <frame_system::Pallet<T>>::block_number(),
-                    None::<BlockNumberFor<T>>,
-                ),
-            );
+              (
+                  <frame_system::Pallet<T>>::block_number(),
+                  None::<BlockNumberFor<T>>,
+              ),
+         );
 
-            Self::deposit_event(Event::TaskReceptionConfirmed { task_id, who });
+          Self::deposit_event(Event::TaskReceptionConfirmed { task_id, who });
 
-            Ok(())
+        Ok(())
         }
 
 		//
@@ -389,30 +392,33 @@ where
 		/// miner confirms that it has reset itself
 		/// Stopped to vacated
 		#[pallet::call_index(6)]
-		#[pallet::weight(<T as pallet::Config>::WeightInfo::confirm_miner_vacation())]
-		pub fn confirm_miner_vacation(origin: OriginFor<T>, task_id: TaskId) -> DispatchResult {
-			let who = ensure_signed(origin)?;
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::confirm_miner_vacation())]
+        pub fn confirm_miner_vacation(origin: OriginFor<T>, task_id: TaskId) -> DispatchResult {
+             let who = ensure_signed(origin)?;
 
-			let mut task = Tasks::<T>::get(task_id).ok_or(Error::<T>::TaskNotFound)?;
+             let mut task = Tasks::<T>::get(task_id).ok_or(Error::<T>::TaskNotFound)?;
 
-			// Ensure task owner is confirming.
-			ensure!(task.task_owner == who, Error::<T>::NotTaskOwner);
+             // Ensure task owner is confirming.
+             ensure!(task.task_owner == who, Error::<T>::NotTaskOwner);
 
-			// Ensure task is stopped.
-			ensure!(
-				task.task_status == TaskStatusType::Stopped,
-				Error::<T>::InvalidTaskState
-			);
+            // Ensure task is stopped.
+            ensure!(
+               task.task_status == TaskStatusType::Stopped,
+               Error::<T>::InvalidTaskState
+           );
 
-			// Move to Vacated state.
-			task.task_status = TaskStatusType::Vacated;
-			Tasks::<T>::insert(task_id, task);
+            // Clear worker busy status
+            Self::clear_worker_busy_status(task_id)?;
 
-			// Emit event.
-			Self::deposit_event(Event::MinerVacated { task_id });
+            // Move to Vacated state.
+            task.task_status = TaskStatusType::Vacated;
+            Tasks::<T>::insert(task_id, task);
 
-			Ok(())
-		}
+            // Emit event.
+            Self::deposit_event(Event::MinerVacated { task_id });
+
+           Ok(())
+        }
 
 		#[pallet::call_index(4)]
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::set_gatekeeper())]
@@ -501,6 +507,53 @@ where
 			} else {
 				Ok(())
 			}
+		}
+
+		fn update_worker_busy_status(task_id: TaskId, is_busy: bool) -> DispatchResult {
+			if let Some(assigned_worker) = TaskAllocations::<T>::get(task_id) {
+				let worker_key = (assigned_worker.0.clone(), assigned_worker.1);
+
+				// Get task to determine worker type
+				if let Some(task_info) = Tasks::<T>::get(task_id) {
+					let worker_type = match task_info.task_kind {
+						TaskKind::NeuroZK => WorkerType::Executable,
+						TaskKind::OpenInference => WorkerType::Executable,
+					};
+
+					// Update busy status
+					// Only set busy if worker exists
+					if pallet_edge_connect::Pallet::<T>::is_registered_miner(&assigned_worker.0) {
+						pallet_edge_connect::Pallet::<T>::set_worker_busy_status_internal(
+							&worker_key,
+							worker_type,
+							is_busy,
+						)?;
+					}
+				}
+			}
+			Ok(())
+		}
+
+		fn clear_worker_busy_status(task_id: TaskId) -> DispatchResult {
+			if let Some(assigned_worker) = TaskAllocations::<T>::get(task_id) {
+				let worker_key = (assigned_worker.0.clone(), assigned_worker.1);
+
+				// Get task to determine worker type
+				if let Some(task_info) = Tasks::<T>::get(task_id) {
+					let worker_type = match task_info.task_kind {
+						TaskKind::NeuroZK => WorkerType::Executable,
+						TaskKind::OpenInference => WorkerType::Executable,
+					};
+
+					// Clear busy status
+					pallet_edge_connect::Pallet::<T>::set_worker_busy_status_internal(
+						&worker_key,
+						worker_type,
+						false,
+					)?;
+				}
+			}
+			Ok(())
 		}
 	}
 


### PR DESCRIPTION
The oracle feeder was unconditionally setting miner status to "active" when detecting online status, even when miners were busy processing tasks. This caused busy miners to incorrectly appear available to users.

This PR implements:
- Automated status management: Busy status is now automatically managed through the task lifecycle:
i. Set to busy when a worker confirms task reception via confirm_task_reception
ii. Cleared when a worker confirms vacation via confirm_miner_vacation
- Status consistency: Added automatic status synchronization - when a worker becomes busy, their visibility status is automatically set to inactive if they were active
- Added `BusyWorkers` storage to track miners currently processing tasks
- Added `safe_update_worker_status` helper function for oracle feeders
