### PR TITLE
feat(task-management): add sudo reset_task extrinsic for manual intervention on stuck tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,15 @@ on:
       - main
       - master
       - dev
+      - 'release/**'
+      - 'v*'
   push:
     branches:
       - main
       - master
       - dev
+      - 'release/**'
+      - 'v*'
 
 jobs:
   ci:
@@ -39,7 +43,7 @@ jobs:
 
       # We've run into out-of-disk error when compiling Polkadot in the next step, so we free up some space this way.
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f1387842cd2f914a1be # 1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # 1.3.1
         with:
           android: true # This alone is a 12 GB save.
           # We disable the rest because it caused some problems. (they're enabled by default)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - master
+      - dev
   push:
     branches:
       - main
       - master
+      - dev
 
 jobs:
   ci:
@@ -37,7 +39,7 @@ jobs:
 
       # We've run into out-of-disk error when compiling Polkadot in the next step, so we free up some space this way.
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # 1.3.1
+        uses: jlumbroso/free-disk-space@54081f1387842cd2f914a1be # 1.3.1
         with:
           android: true # This alone is a 12 GB save.
           # We disable the rest because it caused some problems. (they're enabled by default)

--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -801,7 +801,7 @@ pub mod pallet {
 		}
 
 		/// Lift suspension from a miner
-		fn lift_suspension(
+		pub fn lift_suspension(
 			miner_key: &(T::AccountId, MinerId),
 			miner_type: &MinerType,
 		) -> DispatchResult {

--- a/pallets/task-management/src/lib.rs
+++ b/pallets/task-management/src/lib.rs
@@ -147,7 +147,7 @@ pub mod pallet {
 		/// Event emitted when a task is manually reset by admin
 		TaskManuallyReset {
 			task_id: TaskId,
-			reset_by: T::AccountId,
+			reset_by: Option<T::AccountId>,
 			previous_status: TaskStatusType,
 			reason: ResetReason,
 		},
@@ -553,17 +553,11 @@ where
            miner_type: MinerType,
            reason: ResetReason,
          ) -> DispatchResult {
-           let caller = if let Ok(signed_caller) = ensure_signed(origin.clone()) {
-                signed_caller
-          } else {
-               return Err(DispatchError::BadOrigin);
-           };
-
-            // Ensure this is actually a root call
-             ensure_root(origin)?;
+			// Only root can call this function
+			ensure_root(origin)?;
 
             // Get task information
-            let mut task = Tasks::<T>::get(task_id).ok_or(Error::<T>::TaskNotFound)?;
+            let task = Tasks::<T>::get(task_id).ok_or(Error::<T>::TaskNotFound)?;
             let previous_status = task.task_status.clone();
 
             // Check if task is in a resettable state
@@ -578,33 +572,33 @@ where
             let assigned_miner = TaskAllocations::<T>::get(task_id)
                .ok_or(Error::<T>::UnassignedTaskId)?;
 
+			// Store the assigned block
+			let assigned_block = TaskAssignmentBlock::<T>::get(task_id);
+
             // Reset miner status
             Self::reset_miner_for_task(&assigned_miner, miner_type.clone(), &task_id)?;
 
-            // Update task status to Vacated to allow cleanup
-            task.task_status = TaskStatusType::Vacated;
-            Tasks::<T>::insert(task_id, task);
-
-            // Clean up task allocations and status
+            // Clean up task storage
+            Tasks::<T>::remove(task_id);
             TaskAllocations::<T>::remove(task_id);
             TaskStatus::<T>::remove(task_id);
             TaskAssignmentBlock::<T>::remove(task_id);
+            ComputeAggregations::<T>::remove(task_id);
 
             // Remove from pending confirmations if present
-            if let Some(assigned_block) = TaskAssignmentBlock::<T>::get(task_id) {
+            if let Some(assigned_block) = assigned_block{
               let timeout_block = assigned_block.saturating_add(T::TaskConfirmationTimeout::get());
+
                 PendingTaskConfirmations::<T>::mutate(timeout_block, |tasks| {
-                if let Some(pos) = tasks.iter().position(|&id| id == task_id) {
-                tasks.swap_remove(pos);
+                   if let Some(pos) = tasks.iter().position(|&id| id == task_id) {
+                       tasks.swap_remove(pos);
                }
             });
         }
 
-            // Clean up compute aggregations
-            ComputeAggregations::<T>::remove(task_id);
         Self::deposit_event(Event::TaskManuallyReset {
              task_id,
-             reset_by: caller,
+             reset_by: None,
              previous_status,
              reason,
           });

--- a/pallets/task-management/src/lib.rs
+++ b/pallets/task-management/src/lib.rs
@@ -143,6 +143,14 @@ pub mod pallet {
 		},
 		ModelHashRegistered(Vec<u8>, T::Hash),
 		ModelHashQueried(Vec<u8>, T::Hash),
+
+		/// Event emitted when a task is manually reset by admin
+		TaskManuallyReset {
+			task_id: TaskId,
+			reset_by: T::AccountId,
+			previous_status: TaskStatusType,
+			reason: ResetReason,
+		},
 	}
 
 	/// Errors inform users that something went wrong.
@@ -187,6 +195,30 @@ pub mod pallet {
 		MinerIsInactive,
 		/// Error indicating that the miner is suspended
 		MinerSuspended,
+
+		/// Task cannot be reset in its current state
+		TaskNotResettable,
+		/// Miner reset failed
+		MinerResetFailed,
+	}
+
+	#[derive(
+		PartialEq,
+		Eq,
+		Clone,
+		RuntimeDebug,
+		Encode,
+		Decode,
+		TypeInfo,
+		MaxEncodedLen,
+		DecodeWithMemTracking,
+	)]
+	pub enum ResetReason {
+		MinerUnresponsive,
+		TaskTimeout,
+		SystemError,
+		ManualIntervention,
+		Other,
 	}
 
 	#[pallet::hooks]
@@ -510,6 +542,75 @@ where
 			Self::deposit_event(Event::ModelHashQueried(model_id_fixed.to_vec(), model_hash));
 			Ok(())
 		}
+
+		/// Reset a stuck task and its associated miner (sudo only)
+        /// This allows manual intervention for tasks that are stuck in Assigned, Running, or Stopped states
+        #[pallet::call_index(9)]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::reset_task())]
+        pub fn reset_task(
+           origin: OriginFor<T>,
+           task_id: TaskId,
+           miner_type: MinerType,
+           reason: ResetReason,
+         ) -> DispatchResult {
+           let caller = if let Ok(signed_caller) = ensure_signed(origin.clone()) {
+                signed_caller
+          } else {
+               return Err(DispatchError::BadOrigin);
+           };
+
+            // Ensure this is actually a root call
+             ensure_root(origin)?;
+
+            // Get task information
+            let mut task = Tasks::<T>::get(task_id).ok_or(Error::<T>::TaskNotFound)?;
+            let previous_status = task.task_status.clone();
+
+            // Check if task is in a resettable state
+            if !matches!(
+                task.task_status,
+                TaskStatusType::Assigned | TaskStatusType::Running | TaskStatusType::Stopped
+             ) {
+                 return Err(Error::<T>::TaskNotResettable.into());
+             }
+
+            // Get assigned miner
+            let assigned_miner = TaskAllocations::<T>::get(task_id)
+               .ok_or(Error::<T>::UnassignedTaskId)?;
+
+            // Reset miner status
+            Self::reset_miner_for_task(&assigned_miner, miner_type.clone(), &task_id)?;
+
+            // Update task status to Vacated to allow cleanup
+            task.task_status = TaskStatusType::Vacated;
+            Tasks::<T>::insert(task_id, task);
+
+            // Clean up task allocations and status
+            TaskAllocations::<T>::remove(task_id);
+            TaskStatus::<T>::remove(task_id);
+            TaskAssignmentBlock::<T>::remove(task_id);
+
+            // Remove from pending confirmations if present
+            if let Some(assigned_block) = TaskAssignmentBlock::<T>::get(task_id) {
+              let timeout_block = assigned_block.saturating_add(T::TaskConfirmationTimeout::get());
+                PendingTaskConfirmations::<T>::mutate(timeout_block, |tasks| {
+                if let Some(pos) = tasks.iter().position(|&id| id == task_id) {
+                tasks.swap_remove(pos);
+               }
+            });
+        }
+
+            // Clean up compute aggregations
+            ComputeAggregations::<T>::remove(task_id);
+        Self::deposit_event(Event::TaskManuallyReset {
+             task_id,
+             reset_by: caller,
+             previous_status,
+             reason,
+          });
+
+       Ok(())
+        }
 	}
 
 	impl<T: Config> Pallet<T> {
@@ -581,6 +682,79 @@ where
 			}
 
 			Ok(())
+		}
+
+		/// Reset miner associated with a task
+		fn reset_miner_for_task(
+			miner_key: &(T::AccountId, MinerId),
+			miner_type: MinerType,
+			task_id: &TaskId,
+		) -> DispatchResult {
+			// Get current miner state
+			let miner = pallet_edge_connect::Pallet::<T>::get_miner(miner_key, &miner_type)
+				.ok_or(Error::<T>::MinerResetFailed)?;
+
+			// Only reset if the miner is currently working on this task
+			if let Some(current_task) = miner.current_task {
+				if current_task == *task_id {
+					// Reset miner to available status
+					pallet_edge_connect::Pallet::<T>::update_miner_status(
+						miner_key,
+						miner_type.clone(),
+						true, // set to available
+					)
+					.map_err(|_| Error::<T>::MinerResetFailed)?;
+
+					// Clear current task
+					pallet_edge_connect::Pallet::<T>::update_miner_current_task(miner_key, &miner_type, None)
+						.map_err(|_| Error::<T>::MinerResetFailed)?;
+
+					// If miner was suspended due to this task, lift suspension
+					if miner.is_suspended() {
+						let _ = pallet_edge_connect::Pallet::<T>::lift_suspension(miner_key, &miner_type);
+					}
+				}
+			}
+
+			Ok(())
+		}
+
+		/// Helper function to get all stuck tasks
+		pub fn get_stuck_tasks(
+			current_block: BlockNumberFor<T>,
+			timeout_blocks: BlockNumberFor<T>,
+		) -> Vec<(TaskId, TaskInfo<T::AccountId, BlockNumberFor<T>>)> {
+			let mut stuck_tasks = Vec::new();
+
+			for (task_id, task_info) in Tasks::<T>::iter() {
+				match task_info.task_status {
+					TaskStatusType::Assigned => {
+						// Check if task assignment has timed out
+						if let Some(assigned_block) = TaskAssignmentBlock::<T>::get(task_id) {
+							if current_block.saturating_sub(assigned_block) > timeout_blocks {
+								stuck_tasks.push((task_id, task_info));
+							}
+						}
+					}
+					TaskStatusType::Running => {
+						// Check if task has been running for too long without progress
+						if let Some((start_block, _)) = ComputeAggregations::<T>::get(task_id) {
+							if current_block.saturating_sub(start_block)
+								> timeout_blocks.saturating_mul(10u32.into())
+							{
+								stuck_tasks.push((task_id, task_info));
+							}
+						}
+					}
+					TaskStatusType::Stopped => {
+						// Stopped tasks that haven't been vacated are considered stuck
+						stuck_tasks.push((task_id, task_info));
+					}
+					_ => {} // Vacated tasks are not considered stuck
+				}
+			}
+
+			stuck_tasks
 		}
 	}
 

--- a/pallets/task-management/src/lib.rs
+++ b/pallets/task-management/src/lib.rs
@@ -162,7 +162,6 @@ pub mod pallet {
 		UnexpectedZkFiles,
 		InvalidModelIdLength,
 		NotGatekeeper,
-		TaskNotFound,
 		InvalidModelId,
 		NotAssignedMiner,
 		// Scheduling errors
@@ -170,7 +169,7 @@ pub mod pallet {
 		ZkFilesMissing, // The user submitted a ZK task, but has not provided the required files for proof generation
 
 		// General task errors
-		UnassignedTaskId,         // The provided task ID does not exist.
+		TaskNotFound,         // The provided task ID does not exist.
 		InvalidTaskOwner,         // The caller is not the task owner.
 		TaskVerificationNotFound, // The task verification process cannot be found.
 
@@ -364,10 +363,10 @@ where
             let who = ensure_signed(origin)?;
 
             // Load task
-            let mut task_info = Tasks::<T>::get(task_id).ok_or(Error::<T>::UnassignedTaskId)?;
+            let mut task_info = Tasks::<T>::get(task_id).ok_or(Error::<T>::TaskNotFound)?;
 
             // Check that caller is the assigned worker
-            let assigned_worker = TaskAllocations::<T>::get(task_id).ok_or(Error::<T>::UnassignedTaskId)?;
+            let assigned_worker = TaskAllocations::<T>::get(task_id).ok_or(Error::<T>::TaskNotFound)?;
             ensure!(assigned_worker.0 == who, Error::<T>::InvalidTaskOwner);
 
             // If task is already running, return specific error
@@ -570,7 +569,7 @@ where
 
             // Get assigned miner
             let assigned_miner = TaskAllocations::<T>::get(task_id)
-               .ok_or(Error::<T>::UnassignedTaskId)?;
+               .ok_or(Error::<T>::TaskNotFound)?;
 
 			// Store the assigned block
 			let assigned_block = TaskAssignmentBlock::<T>::get(task_id);

--- a/pallets/task-management/src/tests.rs
+++ b/pallets/task-management/src/tests.rs
@@ -1,16 +1,20 @@
 use crate::{mock::*, Error};
-use crate::{ComputeAggregations, GatekeeperAccount, ModelHashes, NextTaskId, TaskStatus, Tasks};
+use crate::{
+	ComputeAggregations, GatekeeperAccount, ModelHashes, NextTaskId, PendingTaskConfirmations,
+	ResetReason, TaskAllocations, TaskAssignmentBlock, TaskStatus, Tasks,
+};
+pub use cyborg_primitives::miner::*;
 pub use cyborg_primitives::task::NeuroZkTaskSubmissionDetails;
 use cyborg_primitives::task::{
-	AzureTask, NzkData, OnnxTask, OpenInferenceTask, TaskSubmissionData,
+	AzureTask, NzkData, OnnxTask, OpenInferenceTask, TaskId, TaskSubmissionData,
 };
-use frame_support::{assert_noop, assert_ok};
-
-pub use cyborg_primitives::miner::*;
 pub use cyborg_primitives::task::{TaskKind, TaskStatusType};
 use frame_support::dispatch::{DispatchErrorWithPostInfo, PostDispatchInfo};
 use frame_support::BoundedVec;
+use frame_support::{assert_noop, assert_ok};
 use frame_system::pallet_prelude::BlockNumberFor;
+use sp_runtime::DispatchError;
+use sp_runtime::DispatchResult;
 use sp_std::convert::TryFrom;
 
 fn register_miner(
@@ -58,6 +62,14 @@ fn register_miner(
 
 fn setup_gatekeeper() {
 	TaskManagementModule::set_gatekeeper(RuntimeOrigin::root(), 1).unwrap();
+}
+
+fn reset_task_as_root(
+	task_id: TaskId,
+	miner_type: MinerType,
+	reason: ResetReason,
+) -> DispatchResult {
+	TaskManagementModule::reset_task(RuntimeOrigin::root(), task_id, miner_type, reason)
 }
 
 #[test]
@@ -863,5 +875,464 @@ fn test_register_and_retrieve_model_hash() {
 
 		let stored_hash = ModelHashes::<Test>::get(model_id_fixed);
 		assert_eq!(stored_hash, Some(model_hash));
+	});
+}
+
+#[test]
+fn reset_task_should_work_for_stuck_assigned_task() {
+	new_test_ext().execute_with(|| {
+		setup_gatekeeper();
+		System::set_block_number(1);
+		let alice = 1;
+		let executor = 2;
+		let miner_type = MinerType::Edge;
+
+		// Register miner
+		assert_ok!(register_miner(executor, miner_type.clone(), "exec.miner"));
+
+		// Provide compute hours
+		pallet_payment::ComputeHours::<Test>::insert(alice, 20);
+
+		let task_kind = TaskSubmissionData::OpenInference(OpenInferenceTask::Onnx(OnnxTask {
+			storage_location_identifier: BoundedVec::try_from(
+				b"Qmf9v8VbJ6WFGbakeWEXFhUc91V1JG26grakv3dTj8rERh".to_vec(),
+			)
+			.unwrap(),
+			triton_config: None,
+		}));
+
+		// Schedule task
+		assert_ok!(TaskManagementModule::task_scheduler(
+			RuntimeOrigin::signed(alice),
+			task_kind,
+			executor,
+			0, // miner_id
+			Some(10),
+		));
+
+		let task_id = NextTaskId::<Test>::get() - 1;
+
+		// Verify task is in Assigned state
+		let task = Tasks::<Test>::get(task_id).unwrap();
+		assert_eq!(task.task_status, TaskStatusType::Assigned);
+
+		// Verify miner is busy
+		let miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		assert_eq!(miner.operational_status, OperationalStatus::Busy);
+		assert_eq!(miner.current_task, Some(task_id));
+
+		// Reset the stuck task as root using the helper
+		assert_ok!(reset_task_as_root(
+			task_id,
+			miner_type.clone(),
+			ResetReason::MinerUnresponsive
+		));
+
+		// Verify task is removed from storage
+		assert!(Tasks::<Test>::get(task_id).is_none());
+		assert!(TaskAllocations::<Test>::get(task_id).is_none());
+		assert!(TaskStatus::<Test>::get(task_id).is_none());
+		assert!(ComputeAggregations::<Test>::get(task_id).is_none());
+
+		// Verify miner is reset to available
+		let updated_miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		assert_eq!(
+			updated_miner.operational_status,
+			OperationalStatus::Available
+		);
+		assert_eq!(updated_miner.current_task, None);
+
+		// Check event emission
+		System::assert_has_event(RuntimeEvent::TaskManagementModule(
+			crate::Event::TaskManuallyReset {
+				task_id,
+				reset_by: None, // root account
+				previous_status: TaskStatusType::Assigned,
+				reason: ResetReason::MinerUnresponsive,
+			},
+		));
+	});
+}
+
+#[test]
+fn reset_task_should_work_for_stuck_running_task() {
+	new_test_ext().execute_with(|| {
+		setup_gatekeeper();
+		System::set_block_number(1);
+		let alice = 1;
+		let executor = 2;
+		let miner_type = MinerType::Edge;
+
+		// Register miner
+		assert_ok!(register_miner(executor, miner_type.clone(), "exec.miner"));
+
+		// Provide compute hours
+		pallet_payment::ComputeHours::<Test>::insert(alice, 20);
+
+		let task_kind = TaskSubmissionData::OpenInference(OpenInferenceTask::Onnx(OnnxTask {
+			storage_location_identifier: BoundedVec::try_from(
+				b"Qmf9v8VbJ6WFGbakeWEXFhUc91V1JG26grakv3dTj8rERh".to_vec(),
+			)
+			.unwrap(),
+			triton_config: None,
+		}));
+
+		// Schedule task and confirm reception
+		assert_ok!(TaskManagementModule::task_scheduler(
+			RuntimeOrigin::signed(alice),
+			task_kind,
+			executor,
+			0,
+			Some(10),
+		));
+
+		let task_id = NextTaskId::<Test>::get() - 1;
+
+		assert_ok!(TaskManagementModule::confirm_task_reception(
+			RuntimeOrigin::signed(executor),
+			task_id
+		));
+
+		// Verify task is in Running state
+		let task = Tasks::<Test>::get(task_id).unwrap();
+		assert_eq!(task.task_status, TaskStatusType::Running);
+
+		// Reset the stuck running task using root
+		assert_ok!(reset_task_as_root(
+			task_id,
+			miner_type.clone(),
+			ResetReason::TaskTimeout
+		));
+
+		// Verify task is cleaned up
+		assert!(Tasks::<Test>::get(task_id).is_none());
+		assert!(TaskAllocations::<Test>::get(task_id).is_none());
+
+		// Verify miner is reset
+		let updated_miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		assert_eq!(
+			updated_miner.operational_status,
+			OperationalStatus::Available
+		);
+		assert_eq!(updated_miner.current_task, None);
+	});
+}
+
+#[test]
+fn reset_task_should_work_for_stuck_stopped_task() {
+	new_test_ext().execute_with(|| {
+		setup_gatekeeper();
+		System::set_block_number(1);
+		let alice = 1;
+		let executor = 2;
+		let miner_type = MinerType::Edge;
+
+		// Register miner
+		assert_ok!(register_miner(executor, miner_type.clone(), "exec.miner"));
+
+		// Provide compute hours
+		pallet_payment::ComputeHours::<Test>::insert(alice, 20);
+
+		let task_kind = TaskSubmissionData::OpenInference(OpenInferenceTask::Onnx(OnnxTask {
+			storage_location_identifier: BoundedVec::try_from(
+				b"Qmf9v8VbJ6WFGbakeWEXFhUc91V1JG26grakv3dTj8rERh".to_vec(),
+			)
+			.unwrap(),
+			triton_config: None,
+		}));
+
+		// Schedule task and go through full lifecycle to Stopped state
+		assert_ok!(TaskManagementModule::task_scheduler(
+			RuntimeOrigin::signed(alice),
+			task_kind,
+			executor,
+			0,
+			Some(10),
+		));
+
+		let task_id = NextTaskId::<Test>::get() - 1;
+
+		assert_ok!(TaskManagementModule::confirm_task_reception(
+			RuntimeOrigin::signed(executor),
+			task_id
+		));
+
+		// Stop the task
+		assert_ok!(TaskManagementModule::stop_task_and_vacate_miner(
+			RuntimeOrigin::signed(alice),
+			task_id
+		));
+
+		// Verify task is in Stopped state
+		let task = Tasks::<Test>::get(task_id).unwrap();
+		assert_eq!(task.task_status, TaskStatusType::Stopped);
+
+		// Reset the stuck stopped task using root
+		assert_ok!(reset_task_as_root(
+			task_id,
+			miner_type.clone(),
+			ResetReason::ManualIntervention
+		));
+
+		// Verify task is cleaned up
+		assert!(Tasks::<Test>::get(task_id).is_none());
+		assert!(TaskAllocations::<Test>::get(task_id).is_none());
+
+		// Verify miner is reset
+		let updated_miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		assert_eq!(
+			updated_miner.operational_status,
+			OperationalStatus::Available
+		);
+		assert_eq!(updated_miner.current_task, None);
+	});
+}
+
+#[test]
+fn reset_task_should_fail_for_non_root_caller() {
+	new_test_ext().execute_with(|| {
+		setup_gatekeeper();
+		System::set_block_number(1);
+		let alice = 1;
+		let executor = 2;
+		let miner_type = MinerType::Edge;
+
+		// Register miner and create a task
+		assert_ok!(register_miner(executor, miner_type.clone(), "exec.miner"));
+		pallet_payment::ComputeHours::<Test>::insert(alice, 20);
+
+		let task_kind = TaskSubmissionData::OpenInference(OpenInferenceTask::Onnx(OnnxTask {
+			storage_location_identifier: BoundedVec::try_from(
+				b"Qmf9v8VbJ6WFGbakeWEXFhUc91V1JG26grakv3dTj8rERh".to_vec(),
+			)
+			.unwrap(),
+			triton_config: None,
+		}));
+
+		assert_ok!(TaskManagementModule::task_scheduler(
+			RuntimeOrigin::signed(alice),
+			task_kind,
+			executor,
+			0,
+			Some(10),
+		));
+
+		let task_id = NextTaskId::<Test>::get() - 1;
+
+		// Non-root caller should fail
+		assert_noop!(
+			TaskManagementModule::reset_task(
+				RuntimeOrigin::signed(alice),
+				task_id,
+				miner_type,
+				ResetReason::ManualIntervention
+			),
+			DispatchError::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn reset_task_should_fail_for_nonexistent_task() {
+	new_test_ext().execute_with(|| {
+		let nonexistent_task_id = 9999;
+		let miner_type = MinerType::Edge;
+
+		assert_noop!(
+			reset_task_as_root(
+				nonexistent_task_id,
+				miner_type,
+				ResetReason::ManualIntervention
+			),
+			Error::<Test>::TaskNotFound
+		);
+	});
+}
+
+#[test]
+fn reset_task_should_fail_for_non_resettable_states() {
+	new_test_ext().execute_with(|| {
+		setup_gatekeeper();
+		System::set_block_number(1);
+		let alice = 1;
+		let executor = 2;
+		let miner_type = MinerType::Edge;
+
+		// Register miner
+		assert_ok!(register_miner(executor, miner_type.clone(), "exec.miner"));
+		pallet_payment::ComputeHours::<Test>::insert(alice, 20);
+
+		let task_kind = TaskSubmissionData::OpenInference(OpenInferenceTask::Onnx(OnnxTask {
+			storage_location_identifier: BoundedVec::try_from(
+				b"Qmf9v8VbJ6WFGbakeWEXFhUc91V1JG26grakv3dTj8rERh".to_vec(),
+			)
+			.unwrap(),
+			triton_config: None,
+		}));
+
+		// Create task and go through full lifecycle to Vacated state
+		assert_ok!(TaskManagementModule::task_scheduler(
+			RuntimeOrigin::signed(alice),
+			task_kind,
+			executor,
+			0,
+			Some(10),
+		));
+
+		let task_id = NextTaskId::<Test>::get() - 1;
+
+		// Complete the task lifecycle to reach Vacated state
+		assert_ok!(TaskManagementModule::confirm_task_reception(
+			RuntimeOrigin::signed(executor),
+			task_id
+		));
+
+		assert_ok!(TaskManagementModule::stop_task_and_vacate_miner(
+			RuntimeOrigin::signed(alice),
+			task_id
+		));
+
+		assert_ok!(TaskManagementModule::confirm_miner_vacation(
+			RuntimeOrigin::signed(executor),
+			task_id,
+			miner_type.clone()
+		));
+
+		// Verify task is in Vacated state (non-resettable)
+		let task = Tasks::<Test>::get(task_id).unwrap();
+		assert_eq!(task.task_status, TaskStatusType::Vacated);
+
+		assert_noop!(
+			reset_task_as_root(task_id, miner_type, ResetReason::ManualIntervention),
+			Error::<Test>::TaskNotResettable
+		);
+	});
+}
+
+#[test]
+fn reset_task_should_handle_suspended_miner() {
+	new_test_ext().execute_with(|| {
+		setup_gatekeeper();
+		System::set_block_number(1);
+		let alice = 1;
+		let executor = 2;
+		let miner_type = MinerType::Edge;
+
+		// Register miner
+		assert_ok!(register_miner(executor, miner_type.clone(), "exec.miner"));
+
+		// Provide compute hours
+		pallet_payment::ComputeHours::<Test>::insert(alice, 20);
+
+		let task_kind = TaskSubmissionData::OpenInference(OpenInferenceTask::Onnx(OnnxTask {
+			storage_location_identifier: BoundedVec::try_from(
+				b"Qmf9v8VbJ6WFGbakeWEXFhUc91V1JG26grakv3dTj8rERh".to_vec(),
+			)
+			.unwrap(),
+			triton_config: None,
+		}));
+
+		// Schedule task
+		assert_ok!(TaskManagementModule::task_scheduler(
+			RuntimeOrigin::signed(alice),
+			task_kind,
+			executor,
+			0,
+			Some(10),
+		));
+
+		let task_id = NextTaskId::<Test>::get() - 1;
+
+		// Suspend the miner
+		assert_ok!(EdgeConnectModule::suspend_miner(
+			RuntimeOrigin::root(),
+			executor,
+			0,
+			miner_type.clone(),
+			1000, // blocks
+			SuspensionReason::TaskConfirmationTimeout
+		));
+
+		// Verify miner is suspended
+		let miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		assert_eq!(miner.operational_status, OperationalStatus::Suspended);
+
+		// Reset the task - should unsuspend the miner using root
+		assert_ok!(reset_task_as_root(
+			task_id,
+			miner_type.clone(),
+			ResetReason::SystemError
+		));
+
+		// Verify miner is no longer suspended and is available
+		let updated_miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		assert_eq!(
+			updated_miner.operational_status,
+			OperationalStatus::Available
+		);
+		assert_eq!(updated_miner.current_task, None);
+	});
+}
+
+#[test]
+fn reset_task_should_clean_up_pending_confirmations() {
+	new_test_ext().execute_with(|| {
+		setup_gatekeeper();
+		System::set_block_number(1);
+		let alice = 1;
+		let executor = 2;
+		let miner_type = MinerType::Edge;
+
+		// Register miner
+		assert_ok!(register_miner(executor, miner_type.clone(), "exec.miner"));
+		pallet_payment::ComputeHours::<Test>::insert(alice, 20);
+
+		let task_kind = TaskSubmissionData::OpenInference(OpenInferenceTask::Onnx(OnnxTask {
+			storage_location_identifier: BoundedVec::try_from(
+				b"Qmf9v8VbJ6WFGbakeWEXFhUc91V1JG26grakv3dTj8rERh".to_vec(),
+			)
+			.unwrap(),
+			triton_config: None,
+		}));
+
+		// Schedule task
+		assert_ok!(TaskManagementModule::task_scheduler(
+			RuntimeOrigin::signed(alice),
+			task_kind,
+			executor,
+			0,
+			Some(10),
+		));
+
+		let task_id = NextTaskId::<Test>::get() - 1;
+
+		// Verify task is in pending confirmations
+		let assigned_block = TaskAssignmentBlock::<Test>::get(task_id).unwrap();
+		let timeout_block = assigned_block.saturating_add(75);
+		let pending_tasks = PendingTaskConfirmations::<Test>::get(timeout_block);
+
+		// Debug output to help diagnose
+		println!("Assigned block: {}", assigned_block);
+		println!("Timeout block: {}", timeout_block);
+		println!("Pending tasks at timeout block: {:?}", pending_tasks);
+
+		assert!(
+			pending_tasks.contains(&task_id),
+			"Task should be in pending confirmations"
+		);
+
+		// Reset the task using root
+		assert_ok!(reset_task_as_root(
+			task_id,
+			miner_type,
+			ResetReason::ManualIntervention
+		));
+
+		// Verify task is removed from pending confirmations
+		let pending_tasks_after = PendingTaskConfirmations::<Test>::get(timeout_block);
+		assert!(
+			!pending_tasks_after.contains(&task_id),
+			"Task should be removed from pending confirmations"
+		);
 	});
 }

--- a/pallets/task-management/src/tests.rs
+++ b/pallets/task-management/src/tests.rs
@@ -6,16 +6,14 @@ use crate::{
 pub use cyborg_primitives::miner::*;
 pub use cyborg_primitives::task::NeuroZkTaskSubmissionDetails;
 use cyborg_primitives::task::{
-	AzureTask, NzkData, OnnxTask, OpenInferenceTask, TaskId, TaskSubmissionData,
+	AzureTask, OnnxTask, OpenInferenceTask, TaskId, TaskSubmissionData,
 };
 use frame_support::{assert_noop, assert_ok};
 use sp_core::ConstU32;
 
-pub use cyborg_primitives::miner::*;
 pub use cyborg_primitives::task::{TaskKind, TaskStatusType};
 use frame_support::dispatch::{DispatchErrorWithPostInfo, PostDispatchInfo};
 use frame_support::BoundedVec;
-use frame_support::{assert_noop, assert_ok};
 use frame_system::pallet_prelude::BlockNumberFor;
 use sp_runtime::DispatchError;
 use sp_runtime::DispatchResult;
@@ -938,12 +936,15 @@ fn reset_task_should_work_for_stuck_assigned_task() {
 			triton_config: None,
 		}));
 
+		let miner_id: BoundedVec<u8, ConstU32<64>> = 
+			b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec().try_into().unwrap();
+
 		// Schedule task
 		assert_ok!(TaskManagementModule::task_scheduler(
 			RuntimeOrigin::signed(alice),
 			task_kind,
 			executor,
-			0, // miner_id
+			miner_id.clone(),
 			Some(10),
 		));
 
@@ -954,7 +955,7 @@ fn reset_task_should_work_for_stuck_assigned_task() {
 		assert_eq!(task.task_status, TaskStatusType::Assigned);
 
 		// Verify miner is busy
-		let miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		let miner = EdgeConnectModule::get_miner(&(executor, miner_id.clone()), &miner_type).unwrap();
 		assert_eq!(miner.operational_status, OperationalStatus::Busy);
 		assert_eq!(miner.current_task, Some(task_id));
 
@@ -972,7 +973,7 @@ fn reset_task_should_work_for_stuck_assigned_task() {
 		assert!(ComputeAggregations::<Test>::get(task_id).is_none());
 
 		// Verify miner is reset to available
-		let updated_miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		let updated_miner = EdgeConnectModule::get_miner(&(executor, miner_id.clone()), &miner_type).unwrap();
 		assert_eq!(
 			updated_miner.operational_status,
 			OperationalStatus::Available
@@ -1014,12 +1015,15 @@ fn reset_task_should_work_for_stuck_running_task() {
 			triton_config: None,
 		}));
 
+		let miner_id: BoundedVec<u8, ConstU32<64>> = 
+			b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec().try_into().unwrap();
+
 		// Schedule task and confirm reception
 		assert_ok!(TaskManagementModule::task_scheduler(
 			RuntimeOrigin::signed(alice),
 			task_kind,
 			executor,
-			0,
+			miner_id.clone(),
 			Some(10),
 		));
 
@@ -1046,7 +1050,7 @@ fn reset_task_should_work_for_stuck_running_task() {
 		assert!(TaskAllocations::<Test>::get(task_id).is_none());
 
 		// Verify miner is reset
-		let updated_miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		let updated_miner = EdgeConnectModule::get_miner(&(executor, miner_id.clone()), &miner_type).unwrap();
 		assert_eq!(
 			updated_miner.operational_status,
 			OperationalStatus::Available
@@ -1078,12 +1082,15 @@ fn reset_task_should_work_for_stuck_stopped_task() {
 			triton_config: None,
 		}));
 
+		let miner_id: BoundedVec<u8, ConstU32<64>> = 
+			b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec().try_into().unwrap();
+
 		// Schedule task and go through full lifecycle to Stopped state
 		assert_ok!(TaskManagementModule::task_scheduler(
 			RuntimeOrigin::signed(alice),
 			task_kind,
 			executor,
-			0,
+			miner_id.clone(),
 			Some(10),
 		));
 
@@ -1116,7 +1123,7 @@ fn reset_task_should_work_for_stuck_stopped_task() {
 		assert!(TaskAllocations::<Test>::get(task_id).is_none());
 
 		// Verify miner is reset
-		let updated_miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		let updated_miner = EdgeConnectModule::get_miner(&(executor, miner_id.clone()), &miner_type).unwrap();
 		assert_eq!(
 			updated_miner.operational_status,
 			OperationalStatus::Available
@@ -1146,11 +1153,14 @@ fn reset_task_should_fail_for_non_root_caller() {
 			triton_config: None,
 		}));
 
+		let miner_id: BoundedVec<u8, ConstU32<64>> = 
+			b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec().try_into().unwrap();
+
 		assert_ok!(TaskManagementModule::task_scheduler(
 			RuntimeOrigin::signed(alice),
 			task_kind,
 			executor,
-			0,
+			miner_id.clone(),
 			Some(10),
 		));
 
@@ -1207,12 +1217,15 @@ fn reset_task_should_fail_for_non_resettable_states() {
 			triton_config: None,
 		}));
 
+		let miner_id: BoundedVec<u8, ConstU32<64>> = 
+			b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec().try_into().unwrap();
+
 		// Create task and go through full lifecycle to Vacated state
 		assert_ok!(TaskManagementModule::task_scheduler(
 			RuntimeOrigin::signed(alice),
 			task_kind,
 			executor,
-			0,
+			miner_id.clone(),
 			Some(10),
 		));
 
@@ -1269,12 +1282,15 @@ fn reset_task_should_handle_suspended_miner() {
 			triton_config: None,
 		}));
 
+		let miner_id: BoundedVec<u8, ConstU32<64>> = 
+			b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec().try_into().unwrap();
+
 		// Schedule task
 		assert_ok!(TaskManagementModule::task_scheduler(
 			RuntimeOrigin::signed(alice),
 			task_kind,
 			executor,
-			0,
+			miner_id.clone(),
 			Some(10),
 		));
 
@@ -1284,14 +1300,14 @@ fn reset_task_should_handle_suspended_miner() {
 		assert_ok!(EdgeConnectModule::suspend_miner(
 			RuntimeOrigin::root(),
 			executor,
-			0,
+			miner_id.clone(),
 			miner_type.clone(),
 			1000, // blocks
 			SuspensionReason::TaskConfirmationTimeout
 		));
 
 		// Verify miner is suspended
-		let miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		let miner = EdgeConnectModule::get_miner(&(executor, miner_id.clone()), &miner_type).unwrap();
 		assert_eq!(miner.operational_status, OperationalStatus::Suspended);
 
 		// Reset the task - should unsuspend the miner using root
@@ -1302,7 +1318,7 @@ fn reset_task_should_handle_suspended_miner() {
 		));
 
 		// Verify miner is no longer suspended and is available
-		let updated_miner = EdgeConnectModule::get_miner(&(executor, 0), &miner_type).unwrap();
+		let updated_miner = EdgeConnectModule::get_miner(&(executor, miner_id.clone()), &miner_type).unwrap();
 		assert_eq!(
 			updated_miner.operational_status,
 			OperationalStatus::Available
@@ -1332,12 +1348,15 @@ fn reset_task_should_clean_up_pending_confirmations() {
 			triton_config: None,
 		}));
 
+		let miner_id: BoundedVec<u8, ConstU32<64>> = 
+			b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec().try_into().unwrap();
+
 		// Schedule task
 		assert_ok!(TaskManagementModule::task_scheduler(
 			RuntimeOrigin::signed(alice),
 			task_kind,
 			executor,
-			0,
+			miner_id.clone(),
 			Some(10),
 		));
 
@@ -1373,7 +1392,4 @@ fn reset_task_should_clean_up_pending_confirmations() {
 		);
 	});
 }
-//         let stored_hash = ModelHashes::<Test>::get(model_id_fixed);
-//         assert_eq!(stored_hash, Some(model_hash));
-//     });
-// }
+

--- a/pallets/task-management/src/weights.rs
+++ b/pallets/task-management/src/weights.rs
@@ -42,7 +42,7 @@ pub trait WeightInfo {
 	fn set_gatekeeper() -> Weight;
 	fn register_model_hash()-> Weight;
 	fn get_model_hash()->Weight;
-
+	fn reset_task() -> Weight;
 }
 
 /// Weights for `pallet_task_management` using the Substrate node and recommended hardware.
@@ -217,6 +217,31 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 	}
 
+	/// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::TaskAllocations` (r:1 w:1)
+    /// Proof: `TaskManagement::TaskAllocations` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::TaskStatus` (r:1 w:1)
+    /// Proof: `TaskManagement::TaskStatus` (`max_values`: None, `max_size`: Some(17), added: 2492, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::TaskAssignmentBlock` (r:1 w:1)
+    /// Proof: `TaskManagement::TaskAssignmentBlock` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::ComputeAggregations` (r:1 w:1)
+    /// Proof: `TaskManagement::ComputeAggregations` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::PendingTaskConfirmations` (r:1 w:1)
+    /// Proof: `TaskManagement::PendingTaskConfirmations` (`max_values`: None, `max_size`: Some(412), added: 2887, mode: `MaxEncodedLen`)
+    /// Storage: `EdgeConnect::CloudMiners` (r:1 w:1)
+    /// Proof: `EdgeConnect::CloudMiners` (`max_values`: None, `max_size`: Some(223), added: 2698, mode: `MaxEncodedLen`)
+    /// Storage: `EdgeConnect::EdgeMiners` (r:1 w:1)
+    /// Proof: `EdgeConnect::EdgeMiners` (`max_values`: None, `max_size`: Some(223), added: 2698, mode: `MaxEncodedLen`)
+    fn reset_task() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `450`
+        //  Estimated: `7845`
+        // Minimum execution time: 45_000_000 picoseconds.
+        Weight::from_parts(50_000_000, 7845)
+            .saturating_add(T::DbWeight::get().reads(8_u64))
+            .saturating_add(T::DbWeight::get().writes(8_u64))
+    }
 
 }
 
@@ -388,4 +413,14 @@ impl WeightInfo for () {
 		Weight::from_parts(6_500_000, 2560)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 	}
+
+	fn reset_task() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `450`
+        //  Estimated: `7845`
+        // Minimum execution time: 45_000_000 picoseconds.
+        Weight::from_parts(50_000_000, 7845)
+            .saturating_add(RocksDbWeight::get().reads(8_u64))
+            .saturating_add(RocksDbWeight::get().writes(8_u64))
+    }
 }

--- a/primitives/src/miner.rs
+++ b/primitives/src/miner.rs
@@ -1,7 +1,7 @@
+use crate::task::TaskId;
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{pallet_prelude::ConstU32, sp_runtime::RuntimeDebug, BoundedVec};
 use scale_info::TypeInfo;
-use crate::task::TaskId;
 
 pub type MinerId = u64;
 

--- a/primitives/src/oracle.rs
+++ b/primitives/src/oracle.rs
@@ -1,5 +1,5 @@
-use crate::task::TaskId;
 use crate::miner::{MinerId, MinerType};
+use crate::task::TaskId;
 use frame_support::{pallet_prelude::*, traits::Time};
 use orml_oracle::Config;
 use orml_traits;
@@ -74,7 +74,19 @@ pub enum OracleValue {
 	ZkProofResult(bool),
 }
 
-#[derive(Encode, Decode, MaxEncodedLen, Clone, Debug, PartialEq, Eq, TypeInfo, PartialOrd, Ord, DecodeWithMemTracking)]
+#[derive(
+	Encode,
+	Decode,
+	MaxEncodedLen,
+	Clone,
+	Debug,
+	PartialEq,
+	Eq,
+	TypeInfo,
+	PartialOrd,
+	Ord,
+	DecodeWithMemTracking,
+)]
 pub struct OracleMinerFormat<AccoundId> {
 	pub id: (AccoundId, MinerId),
 	pub miner_type: MinerType,

--- a/primitives/src/task.rs
+++ b/primitives/src/task.rs
@@ -4,7 +4,9 @@ use scale_info::TypeInfo;
 
 pub type TaskId = u64;
 
-#[derive(PartialEq, Eq, Clone, Decode, Encode, TypeInfo, Debug, MaxEncodedLen)]
+#[derive(
+	PartialEq, Eq, Clone, Decode, Encode, TypeInfo, Debug, MaxEncodedLen, DecodeWithMemTracking,
+)]
 pub enum TaskStatusType {
 	/// Task has been assigned to a worker, but miner hasn't confirmed reception yet.
 	Assigned,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,9 +47,9 @@ use weights::ExtrinsicBaseWeight;
 pub use frame_system::EnsureRoot;
 
 pub use cyborg_primitives::{
-	oracle::{DummyCombineData, OracleKey, OracleValue, OracleMinerFormat, ProcessStatus},
-	task::TaskId,
 	miner::{MinerId, MinerType},
+	oracle::{DummyCombineData, OracleKey, OracleMinerFormat, OracleValue, ProcessStatus},
+	task::TaskId,
 };
 
 pub use pallet_edge_connect;

--- a/runtime/src/weights/pallet_task_management.rs
+++ b/runtime/src/weights/pallet_task_management.rs
@@ -40,7 +40,7 @@ pub trait WeightInfo {
 	fn set_gatekeeper() -> Weight; 
 	fn register_model_hash()-> Weight;
 	fn get_model_hash()->Weight;
-
+	fn reset_task() -> Weight;
 }
 
 /// Weights for `pallet_task_management` using the Substrate node and recommended hardware.
@@ -227,6 +227,31 @@ impl<T: frame_system::Config> pallet_task_management::WeightInfo for SubstrateWe
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 	}
 
+	/// Storage: `TaskManagement::Tasks` (r:1 w:1)
+    /// Proof: `TaskManagement::Tasks` (`max_values`: None, `max_size`: Some(182), added: 2657, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::TaskAllocations` (r:1 w:1)
+    /// Proof: `TaskManagement::TaskAllocations` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::TaskStatus` (r:1 w:1)
+    /// Proof: `TaskManagement::TaskStatus` (`max_values`: None, `max_size`: Some(17), added: 2492, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::TaskAssignmentBlock` (r:1 w:1)
+    /// Proof: `TaskManagement::TaskAssignmentBlock` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::ComputeAggregations` (r:1 w:1)
+    /// Proof: `TaskManagement::ComputeAggregations` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
+    /// Storage: `TaskManagement::PendingTaskConfirmations` (r:1 w:1)
+    /// Proof: `TaskManagement::PendingTaskConfirmations` (`max_values`: None, `max_size`: Some(412), added: 2887, mode: `MaxEncodedLen`)
+    /// Storage: `EdgeConnect::CloudMiners` (r:1 w:1)
+    /// Proof: `EdgeConnect::CloudMiners` (`max_values`: None, `max_size`: Some(223), added: 2698, mode: `MaxEncodedLen`)
+    /// Storage: `EdgeConnect::EdgeMiners` (r:1 w:1)
+    /// Proof: `EdgeConnect::EdgeMiners` (`max_values`: None, `max_size`: Some(223), added: 2698, mode: `MaxEncodedLen`)
+    fn reset_task() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `450`
+        //  Estimated: `7845`
+        // Minimum execution time: 45_000_000 picoseconds.
+        Weight::from_parts(50_000_000, 7845)
+            .saturating_add(T::DbWeight::get().reads(8_u64))
+            .saturating_add(T::DbWeight::get().writes(8_u64))
+    }
 }
 
 // For backwards compatibility and tests.
@@ -410,5 +435,13 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 	}
 
-
+	fn reset_task() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `450`
+        //  Estimated: `7845`
+        // Minimum execution time: 45_000_000 picoseconds.
+        Weight::from_parts(50_000_000, 7845)
+            .saturating_add(RocksDbWeight::get().reads(8_u64))
+            .saturating_add(RocksDbWeight::get().writes(8_u64))
+    }
 }


### PR DESCRIPTION
Problem: The system has no way for admins to manually fix stuck tasks, causing:

- Miners stuck forever in "Busy" state

- Tasks blocking system resources

- No recovery option without restarting the entire chain

Solution: Added a new admin-only reset_task function that:

- Manually resets stuck tasks and their miners

- Properly cleans up all related states

- Restores system functionality without chain restart