### PR TITLE
Added Maintenance Case

### DIFF
--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -239,7 +239,7 @@ pub mod pallet {
 		pub fn register_miner(
 			origin: OriginFor<T>,
 			miner_type: MinerType,
-			miner_uuid: Vec<u8>,
+			miner_uuid: MinerId,
 			domain: Domain,
 			latitude: Latitude,
 			longitude: Longitude,
@@ -250,29 +250,23 @@ pub mod pallet {
 			let creator = ensure_signed(origin)?;
 
 			let api = MinerAPI { domain };
-			// let miner_keys = AccountMiners::<T>::get(creator.clone());
 			let miner_location = Location {
 				latitude,
 				longitude,
 			};
 			let miner_specs = MinerSpecs { ram, storage, cpu };
 
-			let bounded_uuid: MinerId =
-    miner_uuid.clone().try_into().map_err(|_| Error::<T>::UuidTooLong)?;
-		
-		
-
 				//  Check if the miner already exists
 			let miner_exists = match miner_type {
-				MinerType::Cloud => CloudMiners::<T>::contains_key(bounded_uuid.clone()),
-				MinerType::Edge => EdgeMiners::<T>::contains_key(bounded_uuid.clone()),
+				MinerType::Cloud => CloudMiners::<T>::contains_key(miner_uuid.clone()),
+				MinerType::Edge => EdgeMiners::<T>::contains_key(miner_uuid.clone()),
 			};
 
 			if miner_exists {
 				// Emit an event for re-registration attempt
 				let existing_miner = match miner_type {
-					MinerType::Cloud => CloudMiners::<T>::get(&bounded_uuid),
-					MinerType::Edge => EdgeMiners::<T>::get(&bounded_uuid),
+					MinerType::Cloud => CloudMiners::<T>::get(&miner_uuid),
+					MinerType::Edge => EdgeMiners::<T>::get(&miner_uuid),
 				};
 
 				if let Some(miner) = existing_miner {
@@ -287,7 +281,7 @@ pub mod pallet {
 
 let blocknumber = <frame_system::Pallet<T>>::block_number();
 			let miner = Miner {
-				id: bounded_uuid.clone(),
+				id: miner_uuid.clone(),
 				owner: creator.clone(),
 				location: miner_location,
 				specs: miner_specs,
@@ -301,13 +295,13 @@ let blocknumber = <frame_system::Pallet<T>>::block_number();
 				last_status_check: timestamp::Pallet::<T>::get(),
 			};
 
-			AccountMiners::<T>::insert(creator.clone(), bounded_uuid.clone());
+			AccountMiners::<T>::insert(creator.clone(), miner_uuid.clone());
 
 
 			//  Store miner efficiently
 				match miner_type {
-					MinerType::Cloud => CloudMiners::<T>::insert(&bounded_uuid, miner.clone()),
-					MinerType::Edge => EdgeMiners::<T>::insert(&bounded_uuid, miner.clone()),
+					MinerType::Cloud => CloudMiners::<T>::insert(&miner_uuid, miner.clone()),
+					MinerType::Edge => EdgeMiners::<T>::insert(&miner_uuid, miner.clone()),
 				}
 
 

--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -257,16 +257,10 @@ pub mod pallet {
 			};
 			let miner_specs = MinerSpecs { ram, storage, cpu };
 
-			//  Add CL(Cloud),ED(Edge) based on miner_type
-			let mut full_uuid = match miner_type {
-				MinerType::Cloud => b"CL-".to_vec(),
-				MinerType::Edge => b"ED-".to_vec(),
-			};
-
-			full_uuid.extend_from_slice(&miner_uuid);
-			//  Convert to bounded vec
-			let bounded_uuid: BoundedVec<u8, ConstU32<64>> =
-				full_uuid.clone().try_into().map_err(|_| Error::<T>::UuidTooLong)?;
+			let bounded_uuid: MinerId =
+    miner_uuid.clone().try_into().map_err(|_| Error::<T>::UuidTooLong)?;
+		
+		
 
 				//  Check if the miner already exists
 			let miner_exists = match miner_type {

--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -526,20 +526,32 @@ let blocknumber = <frame_system::Pallet<T>>::block_number();
 			miner_id: MinerId,
 			miner_type: MinerType,
 		) -> DispatchResult {
-			let who = ensure_signed(origin)?;
+			let is_root = ensure_root(origin.clone()).is_ok();
+
+			let who = if is_root {
+				// Root caller: fetch miner owner
+				let miner = Self::get_miner(&miner_id, &miner_type)
+					.ok_or(Error::<T>::MinerDoesNotExist)?;
+				miner.owner.clone()
+			} else {
+				// Normal user caller: ensure signed and get account id
+				ensure_signed(origin.clone())?
+			};
+			
 
 			let mut miner = Self::get_miner(&miner_id, &miner_type)
 				.ok_or(Error::<T>::MinerDoesNotExist)?;
 
-			// Ensure the miner belongs to the caller
-			ensure!(miner.owner == who, Error::<T>::NotAuthorized);
+			// Ensure the miner belongs to the caller (if not root)
+			if !is_root {
+				ensure!(miner.owner == who, Error::<T>::NotAuthorized);
+			}
 
 			// Ensure the miner is in use or busy 
 			ensure!(
 				miner.operational_status == OperationalStatus::Busy,
 				Error::<T>::MinerIsInactive
 			);
-
 			miner.operational_status = OperationalStatus::Maintenance; 
 			miner.status_last_updated = <frame_system::Pallet<T>>::block_number();
 

--- a/pallets/edge-connect/src/lib.rs
+++ b/pallets/edge-connect/src/lib.rs
@@ -91,6 +91,16 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
+	#[pallet::storage]
+	#[pallet::getter(fn miners_under_maintenance)]
+	pub type MinersUnderMaintenance<T:Config>=StorageMap<
+		_,
+		Twox64Concat,
+		MinerId,
+		BlockNumberFor<T>,
+		OptionQuery
+	>;
+
 	/// The `Event` enum contains the various events that can be emitted by this pallet.
 	/// Events are emitted when significant actions or state changes happen in the pallet.
 	#[pallet::event]
@@ -162,6 +172,15 @@ pub mod pallet {
 
 		/// Event emitted when a miner is unsuspended
 		MinerUnsuspended { miner: MinerId },
+
+		/// Maintenance mode resolved by root/admin, miner restored to Available.
+		MaintenanceResolved{miner:MinerId},
+
+		/// Miner has been put under maintenance mode by its owner.
+		MinerUnderMaintenance {
+        miner: MinerId,
+        who: T::AccountId,
+    },
 	}
 
 	#[derive(
@@ -204,6 +223,8 @@ pub mod pallet {
 		NotAuthorized,
 		// Provided UUID exceeded MaxUuidLen
 		UuidTooLong, 
+		//When Miner is not Under Maintenance
+		NotUnderMaintenance
 	}
 
 	// This block defines the dispatchable functions (calls) for the pallet.
@@ -506,6 +527,79 @@ let blocknumber = <frame_system::Pallet<T>>::block_number();
 				worker: (creator, miner_id),
 				status: status_clone,
 			});
+
+			Ok(())
+		}
+
+		#[pallet::call_index(8)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::request_maintenance())]
+		pub fn request_maintenance(
+			origin: OriginFor<T>,
+			miner_id: MinerId,
+			miner_type: MinerType,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+
+			let mut miner = Self::get_miner(&miner_id, &miner_type)
+				.ok_or(Error::<T>::MinerDoesNotExist)?;
+
+			// Ensure the miner belongs to the caller
+			ensure!(miner.owner == who, Error::<T>::NotAuthorized);
+
+			// Ensure the miner is in use or busy 
+			ensure!(
+				miner.operational_status == OperationalStatus::Busy,
+				Error::<T>::MinerIsInactive
+			);
+
+			miner.operational_status = OperationalStatus::Maintenance; 
+			miner.status_last_updated = <frame_system::Pallet<T>>::block_number();
+
+			Self::update_miner(&miner_id, &miner_type, miner);
+
+			// Record maintenance 
+			MinersUnderMaintenance::<T>::insert(
+				&miner_id, 
+				<frame_system::Pallet<T>>::block_number(), 
+			);
+
+			Self::deposit_event(Event::MinerUnderMaintenance {
+				miner: miner_id.clone(),
+				who,
+			});
+
+			Ok(())
+		}
+
+		#[pallet::call_index(9)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::resolve_maintenance())]
+		pub fn resolve_maintenance(
+			origin: OriginFor<T>,
+			miner_id: MinerId,
+			miner_type: MinerType,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+
+			// Fetch miner
+			let mut miner = Self::get_miner(&miner_id, &miner_type)
+				.ok_or(Error::<T>::MinerDoesNotExist)?;
+
+			ensure!(
+				miner.operational_status == OperationalStatus::Maintenance,
+				Error::<T>::NotUnderMaintenance
+			);
+
+			miner.operational_status = OperationalStatus::Available;
+			miner.status_last_updated = <frame_system::Pallet<T>>::block_number();
+
+			Self::update_miner(&miner_id, &miner_type, miner);
+
+			// Remove from maintenance map
+			MinersUnderMaintenance::<T>::remove(&miner_id);
+
+			 Self::deposit_event(Event::MaintenanceResolved {
+					miner: miner_id.clone(),
+				});
 
 			Ok(())
 		}

--- a/pallets/edge-connect/src/tests.rs
+++ b/pallets/edge-connect/src/tests.rs
@@ -23,8 +23,8 @@ fn it_works_for_inserting_miner_into_correct_storage() {
 		System::set_block_number(10);
 		let alice = 0;
 		// UUIDs for each miner
-		let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
-		let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
+		// let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		// let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 		// Full IDs (the pallet adds "CL-" or "ED-" automatically)
 		let bounded_uuid_cloud: BoundedVec<u8, ConstU32<64>> = 
@@ -75,7 +75,7 @@ fn it_works_for_inserting_miner_into_correct_storage() {
 		assert_ok!(EdgeConnectModule::register_miner(
 			RuntimeOrigin::signed(alice),
 			miner_type_0,
-			miner_uuid_cloud.clone(),
+			bounded_uuid_cloud.clone(),
 			domain.clone(),
 			latitude,
 			longitude,
@@ -87,7 +87,7 @@ fn it_works_for_inserting_miner_into_correct_storage() {
 		assert_ok!(EdgeConnectModule::register_miner(
 			RuntimeOrigin::signed(alice),
 			miner_type_1,
-			miner_uuid_edge.clone(),
+			bounded_uuid_edge.clone(),
 			domain.clone(),
 			latitude,
 			longitude,
@@ -126,7 +126,7 @@ fn it_works_for_registering_domain() {
 		System::set_block_number(10);
 		let alice = 0;
 		// UUIDs for each miner
-		let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		// let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
 		// let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 		// Full IDs (the pallet adds "CL-" or "ED-" automatically)
@@ -163,7 +163,7 @@ fn it_works_for_registering_domain() {
 		assert_ok!(EdgeConnectModule::register_miner(
 			RuntimeOrigin::signed(alice),
 			miner_type,
-			miner_uuid_cloud.clone(),
+			bounded_uuid_cloud.clone(),
 			api_info.domain,
 			latitude,
 			longitude,
@@ -196,15 +196,15 @@ fn it_fails_for_registering_duplicate_miner() {
 		let cpu: CpuCores = 12;
 
 		// UUIDs for each miner
-		let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
-		let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
+		// let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		// let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 		// Full IDs (the pallet adds "CL-" or "ED-" automatically)
-		// let bounded_uuid_cloud: BoundedVec<u8, ConstU32<64>> = 
-		// 	b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec().try_into().unwrap();
+		let bounded_uuid_cloud: BoundedVec<u8, ConstU32<64>> = 
+			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec().try_into().unwrap();
 
-		// let bounded_uuid_edge: BoundedVec<u8, ConstU32<64>> = 
-		// 	b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec().try_into().unwrap();
+		let bounded_uuid_edge: BoundedVec<u8, ConstU32<64>> = 
+			b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec().try_into().unwrap();
 
 		let api_info = MinerAPI { domain: domain };
 
@@ -212,7 +212,7 @@ fn it_fails_for_registering_duplicate_miner() {
 		assert_ok!(EdgeConnectModule::register_miner(
 			RuntimeOrigin::signed(alice),
 			miner_type_0.clone(),
-			miner_uuid_cloud.clone(),
+			bounded_uuid_cloud.clone(),
 			api_info.domain.clone(),
 			latitude,
 			longitude,
@@ -225,7 +225,7 @@ fn it_fails_for_registering_duplicate_miner() {
 			EdgeConnectModule::register_miner(
 				RuntimeOrigin::signed(alice),
 				miner_type_0,
-				miner_uuid_cloud.clone(),
+				bounded_uuid_cloud.clone(),
 				api_info.domain.clone(),
 				latitude,
 				longitude,
@@ -240,7 +240,7 @@ fn it_fails_for_registering_duplicate_miner() {
 		assert_ok!(EdgeConnectModule::register_miner(
 			RuntimeOrigin::signed(alice),
 			miner_type_1.clone(),
-			miner_uuid_edge.clone(),
+			bounded_uuid_edge.clone(),
 			api_info.domain.clone(),
 			latitude,
 			longitude,
@@ -253,7 +253,7 @@ fn it_fails_for_registering_duplicate_miner() {
 			EdgeConnectModule::register_miner(
 				RuntimeOrigin::signed(alice),
 				miner_type_1,
-				miner_uuid_edge.clone(),
+				bounded_uuid_edge.clone(),
 				api_info.domain,
 				latitude,
 				longitude,
@@ -282,8 +282,8 @@ fn it_works_for_removing_miner() {
 		let storage: StorageBytes = 100000000;
 		let cpu: CpuCores = 12;
 		// UUIDs for each miner
-		let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
-		let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
+		// let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		// let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 		// Full IDs (the pallet adds "CL-" or "ED-" automatically)
 		let bounded_uuid_cloud: BoundedVec<u8, ConstU32<64>> = 
@@ -297,7 +297,7 @@ fn it_works_for_removing_miner() {
 		assert_ok!(EdgeConnectModule::register_miner(
 			RuntimeOrigin::signed(alice),
 			miner_type_0,
-			miner_uuid_cloud.clone(),
+			bounded_uuid_cloud.clone(),
 			api_info.domain.clone(),
 			latitude,
 			longitude,
@@ -309,7 +309,7 @@ fn it_works_for_removing_miner() {
 		assert_ok!(EdgeConnectModule::register_miner(
 			RuntimeOrigin::signed(alice),
 			miner_type_1,
-			miner_uuid_edge.clone(),
+			bounded_uuid_edge.clone(),
 			api_info.domain.clone(),
 			latitude,
 			longitude,
@@ -381,8 +381,8 @@ fn emiting_proper_event_for_registering_miner() {
 		let ram: RamBytes = 100000000;
 		let storage: StorageBytes = 100000000;
 		let cpu: CpuCores = 12;
-		let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
-		let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
+		// let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		// let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 		// Full IDs (the pallet adds "CL-" or "ED-" automatically)
 		let bounded_uuid_cloud: BoundedVec<u8, ConstU32<64>> = 
@@ -395,7 +395,7 @@ fn emiting_proper_event_for_registering_miner() {
 		assert_ok!(EdgeConnectModule::register_miner(
 			RuntimeOrigin::signed(alice),
 			miner_type,
-			miner_uuid_cloud.clone(),
+			bounded_uuid_cloud.clone(),
 			domain.clone(),
 			latitude,
 			longitude,
@@ -424,7 +424,7 @@ fn it_works_for_requesting_maintenance() {
 		let ram: RamBytes = 100000000;
 		let storage: StorageBytes = 100000000;
 		let cpu: CpuCores = 12;
-		let miner_uuid = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		// let miner_uuid = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
 		let bounded_uuid: BoundedVec<u8, ConstU32<64>> = 
 			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec().try_into().unwrap();
 
@@ -434,7 +434,7 @@ fn it_works_for_requesting_maintenance() {
 		assert_ok!(EdgeConnectModule::register_miner(
 			RuntimeOrigin::signed(alice),
 			miner_type,
-			miner_uuid.clone(),
+			bounded_uuid.clone(),
 			domain.clone(),
 			latitude,
 			longitude,
@@ -479,7 +479,7 @@ fn it_works_for_resolving_maintenance() {
 		let ram: RamBytes = 100000000;
 		let storage: StorageBytes = 100000000;
 		let cpu: CpuCores = 12;
-		let miner_uuid = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		// let miner_uuid = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
 		let bounded_uuid: BoundedVec<u8, ConstU32<64>> = 
 			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec().try_into().unwrap();
 
@@ -489,7 +489,7 @@ fn it_works_for_resolving_maintenance() {
 		assert_ok!(EdgeConnectModule::register_miner(
 			RuntimeOrigin::signed(alice),
 			miner_type,
-			miner_uuid.clone(),
+			bounded_uuid.clone(),
 			domain.clone(),
 			latitude,
 			longitude,
@@ -526,14 +526,14 @@ fn request_maintenance_fails_if_not_owner() {
 		let bob = 1;
 		let domain = BoundedVec::try_from(b"ownerfail.com".to_vec()).unwrap();
 		let miner_type = MinerType::Cloud;
-		let miner_uuid = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		// let miner_uuid = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
 		let bounded_uuid: BoundedVec<u8, ConstU32<64>> =
 			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec().try_into().unwrap();
 
 		assert_ok!(EdgeConnectModule::register_miner(
 			RuntimeOrigin::signed(alice),
 			miner_type,
-			miner_uuid.clone(),
+			bounded_uuid.clone(),
 			domain.clone(),
 			590000,
 			120000,

--- a/pallets/edge-connect/src/tests.rs
+++ b/pallets/edge-connect/src/tests.rs
@@ -23,8 +23,8 @@ fn it_works_for_inserting_miner_into_correct_storage() {
 		System::set_block_number(10);
 		let alice = 0;
 		// UUIDs for each miner
-		let miner_uuid_cloud = b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
-		let miner_uuid_edge  = b"22222222-dddd-eeee-ffff-0987654321cd".to_vec();
+		let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 		// Full IDs (the pallet adds "CL-" or "ED-" automatically)
 		let bounded_uuid_cloud: BoundedVec<u8, ConstU32<64>> = 
@@ -126,8 +126,8 @@ fn it_works_for_registering_domain() {
 		System::set_block_number(10);
 		let alice = 0;
 		// UUIDs for each miner
-		let miner_uuid_cloud = b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
-		// let miner_uuid_edge  = b"22222222-dddd-eeee-ffff-0987654321cd".to_vec();
+		let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		// let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 		// Full IDs (the pallet adds "CL-" or "ED-" automatically)
 		let bounded_uuid_cloud: BoundedVec<u8, ConstU32<64>> = 
@@ -196,8 +196,8 @@ fn it_fails_for_registering_duplicate_miner() {
 		let cpu: CpuCores = 12;
 
 		// UUIDs for each miner
-		let miner_uuid_cloud = b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
-		let miner_uuid_edge  = b"22222222-dddd-eeee-ffff-0987654321cd".to_vec();
+		let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 		// Full IDs (the pallet adds "CL-" or "ED-" automatically)
 		// let bounded_uuid_cloud: BoundedVec<u8, ConstU32<64>> = 
@@ -282,8 +282,8 @@ fn it_works_for_removing_miner() {
 		let storage: StorageBytes = 100000000;
 		let cpu: CpuCores = 12;
 		// UUIDs for each miner
-		let miner_uuid_cloud = b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
-		let miner_uuid_edge  = b"22222222-dddd-eeee-ffff-0987654321cd".to_vec();
+		let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 		// Full IDs (the pallet adds "CL-" or "ED-" automatically)
 		let bounded_uuid_cloud: BoundedVec<u8, ConstU32<64>> = 
@@ -381,8 +381,8 @@ fn emiting_proper_event_for_registering_miner() {
 		let ram: RamBytes = 100000000;
 		let storage: StorageBytes = 100000000;
 		let cpu: CpuCores = 12;
-		let miner_uuid_cloud = b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
-		let miner_uuid_edge  = b"22222222-dddd-eeee-ffff-0987654321cd".to_vec();
+		let miner_uuid_cloud = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		let miner_uuid_edge  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 		// Full IDs (the pallet adds "CL-" or "ED-" automatically)
 		let bounded_uuid_cloud: BoundedVec<u8, ConstU32<64>> = 
@@ -424,7 +424,7 @@ fn it_works_for_requesting_maintenance() {
 		let ram: RamBytes = 100000000;
 		let storage: StorageBytes = 100000000;
 		let cpu: CpuCores = 12;
-		let miner_uuid = b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		let miner_uuid = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
 		let bounded_uuid: BoundedVec<u8, ConstU32<64>> = 
 			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec().try_into().unwrap();
 
@@ -479,7 +479,7 @@ fn it_works_for_resolving_maintenance() {
 		let ram: RamBytes = 100000000;
 		let storage: StorageBytes = 100000000;
 		let cpu: CpuCores = 12;
-		let miner_uuid = b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		let miner_uuid = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
 		let bounded_uuid: BoundedVec<u8, ConstU32<64>> = 
 			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec().try_into().unwrap();
 
@@ -526,7 +526,7 @@ fn request_maintenance_fails_if_not_owner() {
 		let bob = 1;
 		let domain = BoundedVec::try_from(b"ownerfail.com".to_vec()).unwrap();
 		let miner_type = MinerType::Cloud;
-		let miner_uuid = b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		let miner_uuid = b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
 		let bounded_uuid: BoundedVec<u8, ConstU32<64>> =
 			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec().try_into().unwrap();
 

--- a/pallets/edge-connect/src/tests.rs
+++ b/pallets/edge-connect/src/tests.rs
@@ -411,6 +411,152 @@ fn emiting_proper_event_for_registering_miner() {
 	})
 }
 
+#[test]
+fn it_works_for_requesting_maintenance() {
+	new_test_ext().execute_with(|| {
+		let alice = 0;
+		let domain_str = "maintenance_test.com";
+		let domain: BoundedVec<u8, ConstU32<128>> =
+			BoundedVec::try_from(domain_str.as_bytes().to_vec()).unwrap();
+		let miner_type = MinerType::Cloud;
+		let latitude: Latitude = 590000;
+		let longitude: Longitude = 120000;
+		let ram: RamBytes = 100000000;
+		let storage: StorageBytes = 100000000;
+		let cpu: CpuCores = 12;
+		let miner_uuid = b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		let bounded_uuid: BoundedVec<u8, ConstU32<64>> = 
+			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec().try_into().unwrap();
+
+		System::set_block_number(5);
+
+		// Register miner
+		assert_ok!(EdgeConnectModule::register_miner(
+			RuntimeOrigin::signed(alice),
+			miner_type,
+			miner_uuid.clone(),
+			domain.clone(),
+			latitude,
+			longitude,
+			ram,
+			storage,
+			cpu
+		));
+
+		// Set miner status manually to Busy
+		let mut miner = pallet_edge_connect::CloudMiners::<Test>::get(&bounded_uuid).unwrap();
+		miner.operational_status = OperationalStatus::Busy;
+		pallet_edge_connect::CloudMiners::<Test>::insert(&bounded_uuid, miner.clone());
+
+		assert_ok!(EdgeConnectModule::request_maintenance(
+			RuntimeOrigin::signed(alice),
+			bounded_uuid.clone(),
+			MinerType::Cloud
+		));
+
+		let updated = pallet_edge_connect::CloudMiners::<Test>::get(&bounded_uuid).unwrap();
+		assert_eq!(updated.operational_status, OperationalStatus::Maintenance);
+
+		assert!(pallet_edge_connect::MinersUnderMaintenance::<Test>::contains_key(&bounded_uuid));
+
+		System::assert_last_event(RuntimeEvent::EdgeConnectModule(Event::MinerUnderMaintenance {
+			miner: bounded_uuid.clone(),
+			who: alice,
+		}));
+	});
+}
+
+#[test]
+fn it_works_for_resolving_maintenance() {
+	new_test_ext().execute_with(|| {
+		let alice = 0;
+		let domain_str = "resolve_test.com";
+		let domain: BoundedVec<u8, ConstU32<128>> =
+			BoundedVec::try_from(domain_str.as_bytes().to_vec()).unwrap();
+		let miner_type = MinerType::Cloud;
+		let latitude: Latitude = 590000;
+		let longitude: Longitude = 120000;
+		let ram: RamBytes = 100000000;
+		let storage: StorageBytes = 100000000;
+		let cpu: CpuCores = 12;
+		let miner_uuid = b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		let bounded_uuid: BoundedVec<u8, ConstU32<64>> = 
+			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec().try_into().unwrap();
+
+		System::set_block_number(10);
+
+		// Register miner
+		assert_ok!(EdgeConnectModule::register_miner(
+			RuntimeOrigin::signed(alice),
+			miner_type,
+			miner_uuid.clone(),
+			domain.clone(),
+			latitude,
+			longitude,
+			ram,
+			storage,
+			cpu
+		));
+
+		let mut miner = pallet_edge_connect::CloudMiners::<Test>::get(&bounded_uuid).unwrap();
+		miner.operational_status = OperationalStatus::Maintenance;
+		pallet_edge_connect::CloudMiners::<Test>::insert(&bounded_uuid, miner.clone());
+		pallet_edge_connect::MinersUnderMaintenance::<Test>::insert(&bounded_uuid, 10);
+		assert_ok!(EdgeConnectModule::resolve_maintenance(
+			RuntimeOrigin::root(),
+			bounded_uuid.clone(),
+			MinerType::Cloud
+		));
+
+		let updated = pallet_edge_connect::CloudMiners::<Test>::get(&bounded_uuid).unwrap();
+		assert_eq!(updated.operational_status, OperationalStatus::Available);
+
+		assert!(!pallet_edge_connect::MinersUnderMaintenance::<Test>::contains_key(&bounded_uuid));
+
+		System::assert_last_event(RuntimeEvent::EdgeConnectModule(Event::MaintenanceResolved {
+			miner: bounded_uuid.clone(),
+		}));
+	});
+}
+
+#[test]
+fn request_maintenance_fails_if_not_owner() {
+	new_test_ext().execute_with(|| {
+		let alice = 0;
+		let bob = 1;
+		let domain = BoundedVec::try_from(b"ownerfail.com".to_vec()).unwrap();
+		let miner_type = MinerType::Cloud;
+		let miner_uuid = b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec();
+		let bounded_uuid: BoundedVec<u8, ConstU32<64>> =
+			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec().try_into().unwrap();
+
+		assert_ok!(EdgeConnectModule::register_miner(
+			RuntimeOrigin::signed(alice),
+			miner_type,
+			miner_uuid.clone(),
+			domain.clone(),
+			590000,
+			120000,
+			100000000,
+			100000000,
+			12
+		));
+
+		let mut miner = pallet_edge_connect::CloudMiners::<Test>::get(&bounded_uuid).unwrap();
+		miner.operational_status = OperationalStatus::Busy;
+		pallet_edge_connect::CloudMiners::<Test>::insert(&bounded_uuid, miner.clone());
+
+		assert_noop!(
+			EdgeConnectModule::request_maintenance(
+				RuntimeOrigin::signed(bob),
+				bounded_uuid.clone(),
+				MinerType::Cloud
+			),
+			Error::<Test>::NotAuthorized
+		);
+	});
+}
+
 /*
 
 	let domain_str = "some_api_domain.com";

--- a/pallets/edge-connect/src/weights.rs
+++ b/pallets/edge-connect/src/weights.rs
@@ -39,6 +39,8 @@ pub trait WeightInfo {
     fn ban_miner() -> Weight;
 	fn update_operational_status() -> Weight;
     fn unsuspend_miner() -> Weight;
+	fn request_maintenance() -> Weight;
+	fn resolve_maintenance() -> Weight;
 }
 
 /// Weights for `pallet_edge_connect` using the Substrate node and recommended hardware.
@@ -120,6 +122,20 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     }
 
 
+	fn request_maintenance() -> Weight {
+		Weight::from_parts(13_000_000, 4200)
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(2))
+	}
+
+
+	fn resolve_maintenance() -> Weight {
+		Weight::from_parts(12_000_000, 4300)
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(2))
+	}
+
+
 }
 
 // For backwards compatibility and tests.
@@ -190,4 +206,16 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(RocksDbWeight::get().writes(1_u64))
     }
+
+	fn request_maintenance() -> Weight {
+		Weight::from_parts(13_000_000, 4200)
+			.saturating_add(RocksDbWeight::get().reads(1))
+			.saturating_add(RocksDbWeight::get().writes(2))
+	}
+
+	fn resolve_maintenance() -> Weight {
+		Weight::from_parts(12_000_000, 4300)
+			.saturating_add(RocksDbWeight::get().reads(2))
+			.saturating_add(RocksDbWeight::get().writes(2))
+	}
 }

--- a/pallets/status-aggregator/src/tests.rs
+++ b/pallets/status-aggregator/src/tests.rs
@@ -65,9 +65,9 @@ fn on_new_data_works_as_expected() {
 		let oracle_feeder_2: AccountId = 200;
 		let miner_addrs: Vec<AccountId> = [0, 1, 2].to_vec();
 		let miner_ids: Vec<Vec<u8>> = vec![
-			b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
-			b"22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
-			b"33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
+			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
+			b"CL-22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
+			b"CL-33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
 		];
 
 		// Corresponding BoundedVec<_, 64> for MinerId
@@ -271,9 +271,9 @@ fn on_finalize_works_as_expected_for_docker_miners() {
 		let oracle_feeder_2: AccountId = 200;
 		let miner_addrs: Vec<AccountId> = [0, 1, 2].to_vec();
 		let miner_ids: Vec<Vec<u8>> = vec![
-			b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
-			b"22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
-			b"33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
+			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
+			b"CL-22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
+			b"CL-33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
 		];
 
 		// Corresponding BoundedVec<_, 64> for MinerId
@@ -574,9 +574,9 @@ fn on_finalize_works_as_expected_for_executable_miners() {
 		let oracle_feeder_2: AccountId = 200;
 		let miner_addrs: Vec<AccountId> = [0, 1, 2].to_vec();
 		let miner_ids: Vec<Vec<u8>> = vec![
-			b"11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
-			b"22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
-			b"33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
+			b"ED-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
+			b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
+			b"ED-33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
 		];
 
 		// Corresponding BoundedVec<_, 64> for MinerId

--- a/pallets/status-aggregator/src/tests.rs
+++ b/pallets/status-aggregator/src/tests.rs
@@ -64,11 +64,11 @@ fn on_new_data_works_as_expected() {
 		let oracle_feeder_1: AccountId = 100;
 		let oracle_feeder_2: AccountId = 200;
 		let miner_addrs: Vec<AccountId> = [0, 1, 2].to_vec();
-		let miner_ids: Vec<Vec<u8>> = vec![
-			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
-			b"CL-22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
-			b"CL-33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
-		];
+		// let miner_ids: Vec<Vec<u8>> = vec![
+		// 	b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
+		// 	b"CL-22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
+		// 	b"CL-33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
+		// ];
 
 		// Corresponding BoundedVec<_, 64> for MinerId
 		let bounded_miner_ids: Vec<MinerId> = vec![
@@ -85,7 +85,7 @@ fn on_new_data_works_as_expected() {
 		let miner_cpu: CpuCores = 12;
 
 		// register miners
-		for (miner, id_bytes) in miner_addrs.iter().zip(miner_ids.iter()) {
+		for (miner, id_bytes) in miner_addrs.iter().zip(bounded_miner_ids.iter()) {
 			let domain_str = "some_api_domain.".to_owned() + &id_bytes.len().to_string() + ".com"; // you can keep your original domain logic
 			let domain_vec = domain_str.as_bytes().to_vec();
 			let domain: BoundedVec<u8, ConstU32<128>> = BoundedVec::try_from(domain_vec).unwrap();
@@ -270,11 +270,11 @@ fn on_finalize_works_as_expected_for_docker_miners() {
 		let oracle_feeder_1: AccountId = 100;
 		let oracle_feeder_2: AccountId = 200;
 		let miner_addrs: Vec<AccountId> = [0, 1, 2].to_vec();
-		let miner_ids: Vec<Vec<u8>> = vec![
-			b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
-			b"CL-22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
-			b"CL-33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
-		];
+		// let miner_ids: Vec<Vec<u8>> = vec![
+		// 	b"CL-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
+		// 	b"CL-22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
+		// 	b"CL-33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
+		// ];
 
 		// Corresponding BoundedVec<_, 64> for MinerId
 		let bounded_miner_ids: Vec<MinerId> = vec![
@@ -294,7 +294,7 @@ fn on_finalize_works_as_expected_for_docker_miners() {
 		let miner_type = MinerType::Cloud;
 
 		// register miners
-		for (miner, id_bytes) in miner_addrs.iter().zip(miner_ids.iter()) {
+		for (miner, id_bytes) in miner_addrs.iter().zip(bounded_miner_ids.iter()) {
 			let domain_str = "some_api_domain.".to_owned() + &id_bytes.len().to_string() + ".com"; // you can keep your original domain logic
 			let domain_vec = domain_str.as_bytes().to_vec();
 			let domain: BoundedVec<u8, ConstU32<128>> = BoundedVec::try_from(domain_vec).unwrap();
@@ -573,11 +573,11 @@ fn on_finalize_works_as_expected_for_executable_miners() {
 		let oracle_feeder_1: AccountId = 100;
 		let oracle_feeder_2: AccountId = 200;
 		let miner_addrs: Vec<AccountId> = [0, 1, 2].to_vec();
-		let miner_ids: Vec<Vec<u8>> = vec![
-			b"ED-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
-			b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
-			b"ED-33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
-		];
+		// let miner_ids: Vec<Vec<u8>> = vec![
+		// 	b"ED-11111111-aaaa-bbbb-cccc-1234567890ab".to_vec(),
+		// 	b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec(),
+		// 	b"ED-33333333-ffff-gggg-hhhh-abcdef123456".to_vec(),
+		// ];
 
 		// Corresponding BoundedVec<_, 64> for MinerId
 		let bounded_miner_ids: Vec<MinerId> = vec![
@@ -596,7 +596,7 @@ fn on_finalize_works_as_expected_for_executable_miners() {
 
 		// register miners
 		// register miners — one-to-one mapping
-		for (miner, id_bytes) in miner_addrs.iter().zip(miner_ids.iter()) {
+		for (miner, id_bytes) in miner_addrs.iter().zip(bounded_miner_ids.iter()) {
 			let domain_str = "some_api_domain.".to_owned() + &id_bytes.len().to_string() + ".com"; // you can keep your original domain logic
 			let domain_vec = domain_str.as_bytes().to_vec();
 			let domain: BoundedVec<u8, ConstU32<128>> = BoundedVec::try_from(domain_vec).unwrap();

--- a/pallets/task-management/src/tests.rs
+++ b/pallets/task-management/src/tests.rs
@@ -25,12 +25,12 @@ fn register_miner(
 	domain_str: &str,
 ) -> Result<(PostDispatchInfo, MinerId), DispatchErrorWithPostInfo> {
 	// UUIDs for each miner
-	let miner_id  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
+	// let miner_id  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 
 
-	// let bounded_uuid_edge: BoundedVec<u8, ConstU32<64>> = 
-	// 		b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec().try_into().unwrap();
+	let miner_id: BoundedVec<u8, ConstU32<64>> = 
+			b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec().try_into().unwrap();
 	let result = EdgeConnectModule::register_miner(
 		RuntimeOrigin::signed(account),
 		miner_type.clone(),
@@ -169,7 +169,7 @@ fn it_works_for_task_scheduler() {
 
 
 
-		let miner_id_zk: Vec<u8> = b"ED-22222222-dddd-eeee-ffff-0987654321aa".to_vec();
+		// let miner_id_zk: Vec<u8> = b"ED-22222222-dddd-eeee-ffff-0987654321aa".to_vec();
 		let bounded_miner_id_zk: BoundedVec<u8, ConstU32<64>> = 
 			b"ED-22222222-dddd-eeee-ffff-0987654321aa".to_vec().try_into().unwrap();
 		let bob = 3;
@@ -178,7 +178,7 @@ fn it_works_for_task_scheduler() {
 		assert_ok!(EdgeConnectModule::register_miner(
 		RuntimeOrigin::signed(bob),
 		MinerType::Edge,
-		miner_id_zk.clone(),
+		bounded_miner_id_zk.clone(),
 		BoundedVec::try_from("exec.worker".as_bytes().to_vec()).unwrap(),
 		590000,   // latitude
 		120000,   // longitude

--- a/pallets/task-management/src/tests.rs
+++ b/pallets/task-management/src/tests.rs
@@ -25,7 +25,7 @@ fn register_miner(
 	domain_str: &str,
 ) -> Result<(PostDispatchInfo, MinerId), DispatchErrorWithPostInfo> {
 	// UUIDs for each miner
-	let miner_id  = b"22222222-dddd-eeee-ffff-0987654321cd".to_vec();
+	let miner_id  = b"ED-22222222-dddd-eeee-ffff-0987654321cd".to_vec();
 
 
 
@@ -169,7 +169,7 @@ fn it_works_for_task_scheduler() {
 
 
 
-		let miner_id_zk: Vec<u8> = b"22222222-dddd-eeee-ffff-0987654321aa".to_vec();
+		let miner_id_zk: Vec<u8> = b"ED-22222222-dddd-eeee-ffff-0987654321aa".to_vec();
 		let bounded_miner_id_zk: BoundedVec<u8, ConstU32<64>> = 
 			b"ED-22222222-dddd-eeee-ffff-0987654321aa".to_vec().try_into().unwrap();
 		let bob = 3;

--- a/primitives/src/miner.rs
+++ b/primitives/src/miner.rs
@@ -79,6 +79,7 @@ pub enum OperationalStatus {
 	Available, // Miner is available for new tasks (set by miner)
 	Busy,      // Miner is currently processing a task (set by miner)
 	Suspended, // Miner is suspended (set by system via reputation penalties)
+	Maintenance
 }
 
 #[derive(Default, PartialEq, Eq, Clone, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]

--- a/runtime/src/weights/pallet_edge_connect.rs
+++ b/runtime/src/weights/pallet_edge_connect.rs
@@ -37,6 +37,8 @@ pub trait WeightInfo {
     fn ban_miner() -> Weight;
 	fn update_operational_status() -> Weight;
     fn unsuspend_miner() -> Weight;
+	fn request_maintenance() -> Weight;
+	fn resolve_maintenance() -> Weight;
 }
 
 /// Weights for `pallet_edge_connect` using the Substrate node and recommended hardware.
@@ -115,6 +117,18 @@ impl<T: frame_system::Config> pallet_edge_connect::WeightInfo for SubstrateWeigh
             .saturating_add(T::DbWeight::get().reads(1_u64))
             .saturating_add(T::DbWeight::get().writes(1_u64))
     }
+	fn request_maintenance() -> Weight {
+		Weight::from_parts(13_000_000, 4200)
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(2))
+	}
+
+
+	fn resolve_maintenance() -> Weight {
+		Weight::from_parts(12_000_000, 4300)
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(2))
+	}
 }
 
 // For backwards compatibility and tests.
@@ -185,4 +199,15 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().reads(1_u64))
             .saturating_add(RocksDbWeight::get().writes(1_u64))
     }
+	fn request_maintenance() -> Weight {
+		Weight::from_parts(13_000_000, 4200)
+			.saturating_add(RocksDbWeight::get().reads(1))
+			.saturating_add(RocksDbWeight::get().writes(2))
+	}
+
+	fn resolve_maintenance() -> Weight {
+		Weight::from_parts(12_000_000, 4300)
+			.saturating_add(RocksDbWeight::get().reads(2))
+			.saturating_add(RocksDbWeight::get().writes(2))
+	}
 }


### PR DESCRIPTION
- `MinersUnderMaintenance` (StorageMap): Stores miner IDs that are currently under maintenance.
- `request_maintenance` (extrinsic) : Allows a miner to be marked as under maintenance. Moves the miner to maintenance mode instead of suspension for manual debugging.
- `resolve_maintenance` (extrinsic): A sudo-only extrinsic that marks the maintenance as resolved.Returns the miner to an available state after maintenance is completed.